### PR TITLE
Column labels returned by spread() don't match values

### DIFF
--- a/R/spread.R
+++ b/R/spread.R
@@ -48,7 +48,7 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
 
   col <- data[key_col]
   col_id <- dplyr::id(col, drop = TRUE)
-  col_labels <- col[match(unique(col_id), col_id), , drop = FALSE]
+  col_labels <- col[match(sort(unique(col_id)), col_id), , drop = FALSE]
 
   rows <- data[setdiff(names(data), c(key_col, value_col))]
   row_id <- dplyr::id(rows, drop = TRUE)


### PR DESCRIPTION
Labels are reversed for new columns returned by `spread()`. From the demos:

``` r
dadmom <- foreign::read.dta("http://www.ats.ucla.edu/stat/stata/modules/dadmomw.dta")

dadmom %>%
  gather(key, value, named:incm) %>%
  separate(key, c("variable", "type"), -2) %>%
  spread(variable, value, convert = TRUE)
```

Returns:

```
##   famid type  name  inc
## 1     1    d 30000 Bill
## 2     2    d 15000 Bess
## 3     3    d 22000  Art
## 4     1    m 18000  Amy
## 5     2    m 25000 Paul
## 6     3    m 50000  Pat
```

It should return:

```
##   famid type   inc name
## 1     1    d 30000 Bill
## 2     2    d 15000 Bess
## 3     3    d 22000  Art
## 4     1    m 18000  Amy
## 5     2    m 25000 Paul
## 6     3    m 50000  Pat
```

Similar issue with `so-16032858.R`.

Sorting the unique column IDs prior to matching seems to fix the issue. Not sure if this will produce other unintended consequences. 
