### PR TITLE
expand functions added

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -1,0 +1,38 @@
+#' Expanding your data.frame with the magic of expand.grid.
+#' @description
+#' This function expands your data.frame by min to max of the selected columns.
+#' @param df This is the dataframe you want to expand
+#' @param ... Here you enter your colunms (as strings)
+#' @param replace.na = T Replaces the NA which occur by expanding with zeros, very convenient for aggregations 
+#' @param by_unique = F Expands by the unique values in the columns and not from min to max, convenient for strings 
+#' @usage expand(df, ..., replace.na = T, by_unique = F)
+#' @keywords dataframe, expand, aggregations
+#' @export
+#' @examples
+#' data <- data.frame(c(1,2,5), c(3,5,3), c(1,2,3))
+#' names(data) <- c("a", "b", "c")
+#' expand(data, "a", "b")
+#' data%.%expand("a", "b")
+#' 
+#' 
+
+expand <- function(df, ..., replace.na = T, by_unique = F){
+  if(nrow(df) == 0) {
+    return(df)
+  } else {   
+    ex <- list()
+    for (l in list(...)) {
+      if(by_unique) {
+        ex[[l]] <- unique(df[,l])
+      } else {
+        ex[[l]] <- min(df[,l]):max(df[,l])
+      }
+    }
+    grid <- expand.grid(ex)
+    res <- merge(grid, df, all.x = T)
+    if(replace.na){
+      res[is.na(res)] <- 0
+    }
+    return(res)
+  }
+}

--- a/R/expand2.R
+++ b/R/expand2.R
@@ -1,0 +1,34 @@
+#' Expanding your data.frame more flexible then \code{\link{expand}}
+#' @description
+#' This function expands your data.frame by the selected columns. It does not have an global \code{by_unique} like \code{\link{expand}}, but for every single column.
+#' @param df This is the dataframe you want to expand
+#' @param ... Here you enter your arrays with columnname and \code{TRUE} or \code{FALSE}. The latter works like by_unique in \code{\link{expand}}.
+#' @param replace.na = T Replaces the NA which occur by expanding with zeros, very convenient for aggregations 
+#' @usage expand(df, ..., replace.na = T, by_unique = F)
+#' @keywords dataframe, expand, aggregations
+#' @export
+#' @examples
+#' data <- data.frame(c(1,2,5), c(3,5,3), c(1,2,3))
+#' names(data) <- c("a", "b", "c")
+#' expand2(data, c("a", F), c("b", T))
+#' data%.%expand(c("a", T), c("b", F))
+#' 
+#' 
+
+expand2 <- function(df, ..., replace.na = T){
+  ex <- list()
+  for (li in list(...)) {
+    l <- li[1]
+    if(li[2] == T) {
+      ex[[l]] <- unique(df[,l])
+    } else {
+      ex[[l]] <- min(df[,l]):max(df[,l])
+    }
+  }
+  grid <- expand.grid(ex)
+  res <- merge(grid, df, all.x = T)
+  if(replace.na){
+    res[is.na(res)] <- 0
+  }
+  return(res)
+}


### PR DESCRIPTION
Hello Hadley,

i'm a Data Analyst from Germany and love working with your packages, especially _dplyr_. While using the group_by %>% summarize chain, I discovered, that there are only groups made out of existing data. But if I want to group by date, for example, and I don't have data for a specific date, then its does not appear in the grouped result, so I have a "hole", but I would like to have

| Date | n() |
| --- | --- |
| 2014-01-01 | 5 |
| 2014-01-02 | 0 _instead of no data at all_ |
| 2014-01-03 | 7 |

and so on...

I didn't find a solution, so I build a function for it based on expand.grid(). I thought it would be a nice add to tidyr, so take a look at it, maybe you like it (or at least the idea of expanding data). 

You can expand from min:max and by unique ids (which is convenient if you grouped by many variables, like date and gender), and you can select as many expandable columns as you wish.
It works great with the dplyr pipe and I use it a lot.

Feel free to contact me.
