### PR TITLE
add spread_ method for data.table

### DIFF
--- a/R/spread.R
+++ b/R/spread.R
@@ -98,3 +98,38 @@ spread_.tbl_df <- function(data, key_col, value_col, fill = NA,
                            convert = FALSE) {
   dplyr::tbl_df(NextMethod())
 }
+
+
+#' @export
+spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FALSE) {
+  id <- setdiff(names(data), c(key_col, value_col))
+  length_lhs <- length(id)
+  if (!length_lhs) {
+    id <- tempname("temp", data)
+    data[, (id) := 1:.N] 
+  }
+  else{
+    if (anyDuplicated(data, by = c(id))) stop("Duplicate identifiers for rows")
+    }
+  formula <- reformulate(termlabels = key_col , response = id)
+  data2 <- dcast.data.table(data, formula, value.var = value_col, fill = fill)
+  if (!length_lhs) {
+    data[, (id) := NULL]
+    data2[, (id) := NULL]
+  }
+  if (convert) {
+     data2[, names(data2) := lapply(.SD,type.convert, as.is = TRUE), .SDcols = names(data2)]
+   }
+  data2
+}
+
+#' @export
+spread_.tbl_dt <- function(data, key_col, value_col, fill = NA,
+                           convert = FALSE) {
+  dplyr::tbl_dt(NextMethod())
+}
+
+
+
+
+

--- a/R/spread.R
+++ b/R/spread.R
@@ -120,7 +120,7 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
         stop("Duplicate identifiers for rows ", paste(str, collapse = ", "),
              call. = FALSE)
   }
-  formula <- reformulate(termlabels = key_col , response = id)
+  formula <- as.formula(paste(paste(id, collapse = "+"), paste(key_col, collapse = "+"), sep = "~"))
   data2 <- dcast.data.table(data, formula, value.var = value_col, fill = fill, drop = drop)
   if (!length_lhs) {
     data2[, (id) := NULL]

--- a/R/spread.R
+++ b/R/spread.R
@@ -108,8 +108,8 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
   length_lhs <- length(id)
   if (!length_lhs) {
     id <- tempname("temp", data)
+    data <- shallow(data)
     data[, (id) := 1] 
-    on.exit(data[, (id) := NULL])
   }
   if (anyDuplicated(data, by = c(id, key_col))){
         overall <- dplyr::id(data[,c(id, key_col), with = FALSE])

--- a/R/spread.R
+++ b/R/spread.R
@@ -109,9 +109,15 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
     data[, (id) := 1:.N] 
     on.exit(data[, (id) := NULL])
   }
-  else{
-    if (anyDuplicated(data, by = c(id))) stop("Duplicate identifiers for rows")
-    }
+  else if (anyDuplicated(data, by = c(id, key_col))){
+        overall <- dplyr::id(data[,c(id, key_col), with = FALSE])
+        groups <- split(seq_along(overall), overall)
+        groups <- groups[vapply(groups, length, integer(1)) > 1]
+        str <- vapply(groups, function(x) paste0("(", paste0(x, collapse = ", "), ")"),
+             character(1))
+        stop("Duplicate identifiers for rows ", paste(str, collapse = ", "),
+             call. = FALSE)
+  }
   formula <- reformulate(termlabels = key_col , response = id)
   data2 <- dcast.data.table(data, formula, value.var = value_col, fill = fill)
   if (!length_lhs) {

--- a/R/spread.R
+++ b/R/spread.R
@@ -108,7 +108,7 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
   length_lhs <- length(id)
   if (!length_lhs) {
     id <- tempname("temp", data)
-    data[, (id) := 1:.N] 
+    data[, (id) := 1] 
     on.exit(data[, (id) := NULL])
   }
   else if (anyDuplicated(data, by = c(id, key_col))){

--- a/R/spread.R
+++ b/R/spread.R
@@ -1,3 +1,4 @@
+
 #' Spread a key-value pair across multiple columns.
 #'
 #' @param key,value Bare (unquoted) names of key and value columns.
@@ -18,11 +19,11 @@
 #' # Spread and gather are complements
 #' df <- data.frame(x = c("a", "b"), y = c(3, 4), z = c(5, 6))
 #' df %>% spread(x, y) %>% gather(x, y, a:b, na.rm = TRUE)
-spread <- function(data, key, value, fill = NA, convert = FALSE) {
+spread <- function(data, key, value, fill = NA, convert = FALSE, drop = TRUE) {
   key_col <- col_name(substitute(key))
   value_col <- col_name(substitute(value))
 
-  spread_(data, key_col, value_col, fill = fill, convert = convert)
+  spread_(data, key_col, value_col, fill = fill, convert = convert, drop = drop)
 }
 
 #' Standard-evaluation version of \code{spread}.
@@ -37,22 +38,25 @@ spread <- function(data, key, value, fill = NA, convert = FALSE) {
 #'   \code{asis = TRUE} will be run on each of the new columns. This is
 #'   useful if the value column was a mix of variables that was coerced to
 #'   a string.
+#' @param drop If \code{FALSE}, will keep factor levels that don't appear
+#'   in the data, filling in missing combinations with \code{fill}.
 #' @export
-spread_ <- function(data, key_col, value_col, fill = NA, convert = FALSE) {
+spread_ <- function(data, key_col, value_col, fill = NA, convert = FALSE,
+                    drop = TRUE) {
   UseMethod("spread_")
 }
 
 #' @export
 spread_.data.frame <- function(data, key_col, value_col, fill = NA,
-                               convert = FALSE) {
+                               convert = FALSE, drop = TRUE) {
 
   col <- data[key_col]
-  col_id <- dplyr::id(col, drop = TRUE)
-  col_labels <- col[match(sort(unique(col_id)), col_id), , drop = FALSE]
+  col_id <- dplyr::id(col, drop = drop)
+  col_labels <- split_labels(col, col_id, drop = drop)
 
   rows <- data[setdiff(names(data), c(key_col, value_col))]
-  row_id <- dplyr::id(rows, drop = TRUE)
-  row_labels <- rows[match(sort(unique(row_id)), row_id), , drop = FALSE]
+  row_id <- dplyr::id(rows, drop = drop)
+  row_labels <- split_labels(rows, row_id, drop = drop)
   rownames(row_labels) <- NULL
 
   overall <- dplyr::id(list(col_id, row_id), drop = FALSE)
@@ -83,25 +87,23 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
   }
 
   dim(ordered) <- c(attr(row_id, "n"), attr(col_id, "n"))
+  ordered <- as.data.frame.matrix(ordered, stringsAsFactors = FALSE)
   colnames(ordered) <- as.character(col_labels[[1]])
-  ordered <- as.data.frame(ordered, stringsAsFactors = FALSE)
 
   if (convert) {
     ordered[] <- lapply(ordered, type.convert, as.is = TRUE)
   }
-
   append_df(row_labels, ordered)
 }
 
 #' @export
 spread_.tbl_df <- function(data, key_col, value_col, fill = NA,
-                           convert = FALSE) {
+                           convert = FALSE, drop = TRUE) {
   dplyr::tbl_df(NextMethod())
 }
 
-
 #' @export
-spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FALSE) {
+spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FALSE, drop = TRUE) {
   id <- setdiff(names(data), c(key_col, value_col))
   length_lhs <- length(id)
   if (!length_lhs) {
@@ -119,7 +121,7 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
              call. = FALSE)
   }
   formula <- reformulate(termlabels = key_col , response = id)
-  data2 <- dcast.data.table(data, formula, value.var = value_col, fill = fill)
+  data2 <- dcast.data.table(data, formula, value.var = value_col, fill = fill, drop = drop)
   if (!length_lhs) {
     data2[, (id) := NULL]
   }
@@ -131,11 +133,31 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
 
 #' @export
 spread_.tbl_dt <- function(data, key_col, value_col, fill = NA,
-                           convert = FALSE) {
+                           convert = FALSE, drop = TRUE) {
   dplyr::tbl_dt(NextMethod())
 }
 
 
+split_labels <- function(df, id, drop = TRUE) {
+  if (length(df) == 0) {
+    return(df)
+  }
 
+  if (drop) {
+    representative <- match(sort(unique(id)), id)
+    df[representative, , drop = FALSE]
+  } else {
+    unique_values <- lapply(df, ulevels)
+    rev(expand.grid(rev(unique_values), stringsAsFactors = FALSE))
+  }
+}
 
-
+ulevels <- function(x) {
+  if (is.factor(x)) {
+    x <- addNA(x, ifany = TRUE)
+    levs <- levels(x)
+    factor(levs, levels = levs)
+  } else {
+    sort(unique(x))
+  }
+}

--- a/R/spread.R
+++ b/R/spread.R
@@ -107,6 +107,7 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
   if (!length_lhs) {
     id <- tempname("temp", data)
     data[, (id) := 1:.N] 
+    on.exit(data[, (id) := NULL])
   }
   else{
     if (anyDuplicated(data, by = c(id))) stop("Duplicate identifiers for rows")
@@ -114,7 +115,6 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
   formula <- reformulate(termlabels = key_col , response = id)
   data2 <- dcast.data.table(data, formula, value.var = value_col, fill = fill)
   if (!length_lhs) {
-    data[, (id) := NULL]
     data2[, (id) := NULL]
   }
   if (convert) {

--- a/R/spread.R
+++ b/R/spread.R
@@ -111,7 +111,7 @@ spread_.data.table <- function(data, key_col, value_col, fill = NA, convert = FA
     data[, (id) := 1] 
     on.exit(data[, (id) := NULL])
   }
-  else if (anyDuplicated(data, by = c(id, key_col))){
+  if (anyDuplicated(data, by = c(id, key_col))){
         overall <- dplyr::id(data[,c(id, key_col), with = FALSE])
         groups <- split(seq_along(overall), overall)
         groups <- groups[vapply(groups, length, integer(1)) > 1]

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,7 +40,6 @@ extract_numeric <- function(x) {
 
 "%||%" <- function(a, b) if (is.null(a)) b else a
 
-
 tempname=function(prefix, where, inherits=TRUE) {
     i <- 0L
     name <- prefix
@@ -49,4 +48,10 @@ tempname=function(prefix, where, inherits=TRUE) {
         name <- paste0(prefix, as.character(i))
     }
     name
+}
+
+shallow_ <- function(x) {
+    out = as.list(x)
+    setDT(out)
+    out
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -39,3 +39,14 @@ extract_numeric <- function(x) {
 }
 
 "%||%" <- function(a, b) if (is.null(a)) b else a
+
+
+tempname=function(prefix, where, inherits=TRUE) {
+    i <- 0L
+    name <- prefix
+    while (exists(name, where = where, inherits = inherits)) {
+        i <- i + 1L
+        name <- paste0(prefix, as.character(i))
+    }
+    name
+}


### PR DESCRIPTION
`gather_`  works directly on data.table since it uses reshape2::melt. However, it is not the case for `spread_`. So I've written a method for data.table using dcast.data.table