### PR TITLE
respect input class

### DIFF
--- a/R/gather.R
+++ b/R/gather.R
@@ -84,3 +84,9 @@ gather_.tbl_df <- function(data, key_col, value_col, gather_cols,
                            na.rm = FALSE, convert = FALSE) {
   dplyr::tbl_df(NextMethod())
 }
+
+#' @export
+gather_.tbl_dt <- function(data, key_col, value_col, gather_cols,
+                           na.rm = FALSE, convert = FALSE) {
+  dplyr::tbl_dt(NextMethod())
+}

--- a/tests/testthat/test-gather.R
+++ b/tests/testthat/test-gather.R
@@ -16,3 +16,9 @@ test_that("if not supply, key and value default to key and value", {
   expect_equal(nrow(out), 2)
   expect_equal(names(out), c("key", "value"))
 })
+
+test_that("preserve class of input", {
+  dat <- data.frame(x = 1:2)
+  dat %>% tbl_df %>% gather %>% expect_is("tbl_df")
+  dat %>% tbl_df %>% gather %>% expect_is("tbl_df")
+})

--- a/tests/testthat/test-spread.R
+++ b/tests/testthat/test-spread.R
@@ -45,3 +45,15 @@ test_that("drop = FALSE keeps missing combinations (#25)", {
   expect_equal(out$a[2], 1)
 
 })
+
+test_that("preserve class of input", {
+  dat <- data.frame(
+    x = c("a", "a", "b", "b"),
+    y = c("c", "d", "c", "d"),
+    z = c("w", "x", "y", "z")
+  )
+  dat %>% tbl_df %>% spread(x, z) %>% expect_is("tbl_df")
+  dat %>% tbl_dt %>% spread(x, z) %>% expect_is("tbl_dt")
+})
+
+


### PR DESCRIPTION
Gathering a `tbl_dt` should produce a `tbl_dt`. Add `gather_.tbl_dt` and
tests. (Also add tests for `spread`.)