### PR TITLE
Fixing duplicate "Suggests:" fields in DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,9 @@ Imports:
     stringi,
     lazyeval
 Suggests:
-    data.table
-URL: https://github.com/hadley/tidyr
-BugReports: https://github.com/hadley/tidyr/issues
-Suggests:
+    data.table,
     knitr,
     testthat
+URL: https://github.com/hadley/tidyr
+BugReports: https://github.com/hadley/tidyr/issues
 VignetteBuilder: knitr


### PR DESCRIPTION
I removed the duplicate "Suggests:" field and tidyr installs fine now. Should fix #74 