### PR TITLE
Fix confusing wording in unite() description

### DIFF
--- a/R/unite.R
+++ b/R/unite.R
@@ -1,6 +1,6 @@
 #' Unite multiple columns into one.
 #'
-#' Convenience function to paste together multiple functions into one.
+#' Convenience function to paste together multiple columns into one.
 #'
 #' @inheritParams unite_
 #' @param col (Bare) name of column to add

--- a/man/unite.Rd
+++ b/man/unite.Rd
@@ -20,7 +20,7 @@ Select all variables between x and z with \code{x:z}, exclude y with
 \item{remove}{If \code{TRUE}, remove input columns from output data frame.}
 }
 \description{
-Convenience function to paste together multiple functions into one.
+Convenience function to paste together multiple columns into one.
 }
 \examples{
 library(dplyr)


### PR DESCRIPTION
`unite()` documentation description currently states: "Convenience function to paste together multiple functions into one."  I replaced "functions" with "columns", which I think was what was intended.