### PR TITLE
Avoid warning thrown by split.data.frame()

### DIFF
--- a/R/unnest.R
+++ b/R/unnest.R
@@ -74,7 +74,7 @@ unnest_.data.frame <- function(data, unnest_cols) {
   }
 
   types <- vapply(nested, list_col_type, character(1))
-  nested <- split(nested, types)
+  nested <- split.default(nested, types)
   if (length(nested$mixed) > 0) {
     probs <- paste(names(nested$mixed), collapse = ",")
     stop("Each column must either be a list of vectors or a list of ",

--- a/tests/testthat/test-unnest.R
+++ b/tests/testthat/test-unnest.R
@@ -30,3 +30,10 @@ test_that("multiple columns must be same length", {
   df <- dplyr::data_frame(x = list(1), y = list(dplyr::data_frame(x = 1:2)))
   expect_error(unnest(df), "same number of elements")
 })
+
+test_that("nested is split as a list (#84)", {
+  df <- dplyr::data_frame(x = 1:3, y = list(1,2:3,4), z = list(5,6:7,8))
+  expect_that(unnest(df), not(gives_warning("data length is not a multiple")))
+})
+
+


### PR DESCRIPTION
`nested` should be split as a list, not a data.frame. Otherwise `split.data.frame()` throws a warning when the number of rows in `nested` is not a multiple of the length of `types`.

Example:

```
unnest(data_frame(x = 1:3, y = list(1,2:3,4), z = list(5,6:7,8)))
## Warning message:
In split.default(x = seq_len(nrow(x)), f = f, drop = drop, ...) :
  data length is not a multiple of split variable
```

