### PR TITLE
do type conversion after reshaping in spread(); fixes #118

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr 0.3.1.9000
 
+* `spread()` once again creates columns of mixed type when `convert = TRUE` (#118, @jennybc)
+
 # tidyr 0.3.1
 
 * Fixed bug where attributes of non-gather columns were lost (#104)

--- a/R/spread.R
+++ b/R/spread.R
@@ -94,14 +94,21 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
   if (!is.na(fill)) {
     ordered[is.na(ordered)] <- fill
   }
-  if (convert) {
-    ordered <- type.convert(ordered, as.is = TRUE)
-  }
 
   dim(ordered) <- c(attr(row_id, "n"), attr(col_id, "n"))
   colnames(ordered) <- as.character(col_labels[[1]])
+  ordered <- as.data.frame.matrix(ordered, stringsAsFactors = FALSE)
 
-  append_df(row_labels, matrixToDataFrame(ordered))
+  if (convert) {
+    ordered[] <- lapply(ordered, type.convert, as.is = TRUE)
+  }
+
+  ordered[] <- lapply(ordered, inherit_attributes, value)
+  if (is.factor(value) && drop) {
+    ordered[] <- lapply(ordered, factor)
+  }
+
+  append_df(row_labels, ordered)
 }
 
 #' @export
@@ -132,4 +139,11 @@ ulevels <- function(x) {
   } else {
     sort(unique(x))
   }
+}
+
+inherit_attributes <- function(target, source) {
+  if (is.factor(source))
+    target <- factor(target, levels = levels(source))
+  attributes(target) <- attributes(source)
+  target
 }

--- a/R/spread.R
+++ b/R/spread.R
@@ -97,7 +97,7 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
 
   dim(ordered) <- c(attr(row_id, "n"), attr(col_id, "n"))
   colnames(ordered) <- as.character(col_labels[[1]])
-  ordered <- as.data.frame.matrix(ordered, stringsAsFactors = FALSE)
+  ordered <- matrixToDataFrame(ordered)
 
   if (convert) {
     ordered[] <- lapply(ordered, type.convert, as.is = TRUE)

--- a/R/spread.R
+++ b/R/spread.R
@@ -103,7 +103,6 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
     ordered[] <- lapply(ordered, type.convert, as.is = TRUE)
   }
 
-  ordered[] <- lapply(ordered, inherit_attributes, value)
   if (is.factor(value) && drop) {
     ordered[] <- lapply(ordered, factor)
   }
@@ -139,11 +138,4 @@ ulevels <- function(x) {
   } else {
     sort(unique(x))
   }
-}
-
-inherit_attributes <- function(target, source) {
-  if (is.factor(source))
-    target <- factor(target, levels = levels(source))
-  attributes(target) <- attributes(source)
-  target
 }

--- a/R/spread.R
+++ b/R/spread.R
@@ -114,10 +114,6 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
     ordered[] <- lapply(ordered, type.convert, as.is = TRUE)
   }
 
-  if (is.factor(ordered[[1]]) && drop) {
-    ordered[] <- lapply(ordered, factor)
-  }
-
   append_df(row_labels, ordered)
 }
 

--- a/R/spread.R
+++ b/R/spread.R
@@ -114,7 +114,7 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
     ordered[] <- lapply(ordered, type.convert, as.is = TRUE)
   }
 
-  if (is.factor(value) && is.factor(ordered[[1]]) && drop) {
+  if (is.factor(ordered[[1]]) && drop) {
     ordered[] <- lapply(ordered, factor)
   }
 

--- a/R/spread.R
+++ b/R/spread.R
@@ -18,6 +18,13 @@
 #' # Spread and gather are complements
 #' df <- data.frame(x = c("a", "b"), y = c(3, 4), z = c(5, 6))
 #' df %>% spread(x, y) %>% gather(x, y, a:b, na.rm = TRUE)
+#'
+#' # Use 'convert = TRUE' to produce variables of mixed type
+#' df <- data.frame(row = rep(c(1, 51), each = 3),
+#'                  var = c("Sepal.Length", "Species", "Species_num"),
+#'                  value = c(5.1, "setosa", 1, 7.0, "versicolor", 2))
+#' df %>% spread(var, value) %>% str
+#' df %>% spread(var, value, convert = TRUE) %>% str
 spread <- function(data, key, value, fill = NA, convert = FALSE, drop = TRUE) {
   key_col <- col_name(substitute(key))
   value_col <- col_name(substitute(value))
@@ -31,17 +38,18 @@ spread <- function(data, key, value, fill = NA, convert = FALSE, drop = TRUE) {
 #'
 #' @param data A data frame.
 #' @param key_col,value_col Strings giving names of key and value cols.
-#' @param fill If set, missing values will be replaced with this value.
-#'   Note that there are two types of missingness in the input: explicit
-#'   missing values (i.e. \code{NA}), and implicit missings, rows that
-#'   simply aren't present. Both types of missing value will be replaced by
-#'   \code{fill}.
-#' @param convert If \code{TRUE}, \code{\link{type.convert}} with
-#'   \code{asis = TRUE} will be run on each of the new columns. This is
-#'   useful if the value column was a mix of variables that was coerced to
-#'   a string.
-#' @param drop If \code{FALSE}, will keep factor levels that don't appear
-#'   in the data, filling in missing combinations with \code{fill}.
+#' @param fill If set, missing values will be replaced with this value. Note
+#'   that there are two types of missingness in the input: explicit missing
+#'   values (i.e. \code{NA}), and implicit missings, rows that simply aren't
+#'   present. Both types of missing value will be replaced by \code{fill}.
+#' @param convert If \code{TRUE}, \code{\link{type.convert}} with \code{asis =
+#'   TRUE} will be run on each of the new columns. This is useful if the value
+#'   column was a mix of variables that was coerced to a string. If the class of
+#'   the value column was factor or date, note that will not be true of the new
+#'   columns that are produced, which are coerced to character before type
+#'   conversion.
+#' @param drop If \code{FALSE}, will keep factor levels that don't appear in the
+#'   data, filling in missing combinations with \code{fill}.
 #' @export
 spread_ <- function(data, key_col, value_col, fill = NA, convert = FALSE,
                     drop = TRUE) {
@@ -100,10 +108,13 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
   ordered <- matrixToDataFrame(ordered)
 
   if (convert) {
+    if (!is.character(ordered[[1]])) {
+      ordered[] <- lapply(ordered, as.character)
+    }
     ordered[] <- lapply(ordered, type.convert, as.is = TRUE)
   }
 
-  if (is.factor(value) && drop) {
+  if (is.factor(value) && is.factor(ordered[[1]]) && drop) {
     ordered[] <- lapply(ordered, factor)
   }
 

--- a/R/spread.R
+++ b/R/spread.R
@@ -103,14 +103,14 @@ spread_.data.frame <- function(data, key_col, value_col, fill = NA,
     ordered[is.na(ordered)] <- fill
   }
 
+  if (convert && !is.character(ordered)) {
+    ordered <- as.character(ordered)
+  }
   dim(ordered) <- c(attr(row_id, "n"), attr(col_id, "n"))
   colnames(ordered) <- as.character(col_labels[[1]])
   ordered <- matrixToDataFrame(ordered)
 
   if (convert) {
-    if (!is.character(ordered[[1]])) {
-      ordered[] <- lapply(ordered, as.character)
-    }
     ordered[] <- lapply(ordered, type.convert, as.is = TRUE)
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tidyr
 
-[![Build Status](https://travis-ci.org/hadley/tidyr.png?branch=master)](https://travis-ci.org/hadley/tidyr) 
+[![Build Status](https://travis-ci.org/hadley/tidyr.svg?branch=master)](https://travis-ci.org/hadley/tidyr) 
 [![codecov.io](http://codecov.io/github/hadley/tidyr/coverage.svg?branch=master)](http://codecov.io/github/hadley/tidyr?branch=master)
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/tidyr)](http://cran.r-project.org/package=tidyr)
 

--- a/man/separate.Rd
+++ b/man/separate.Rd
@@ -35,7 +35,7 @@ columns are integer, numeric or logical.}
   happens when there are too many pieces. There are three valid options:
 
   \itemize{
-   \item "warn" (the default): emit a waring and drop extra values.
+   \item "warn" (the default): emit a warning and drop extra values.
    \item "drop": drop any extra values without a warning.
    \item "merge": only splits at most \code{length(into)} times
   }}
@@ -44,7 +44,7 @@ columns are integer, numeric or logical.}
   happens when there are not enough pieces. There are three valid options:
 
   \itemize{
-   \item "warn" (the default): emit a waring and fill from the right
+   \item "warn" (the default): emit a warning and fill from the right
    \item "right": fill with missing values on the right
    \item "left": fill with missing values on the left
   }}

--- a/man/separate_.Rd
+++ b/man/separate_.Rd
@@ -35,7 +35,7 @@ columns are integer, numeric or logical.}
   happens when there are too many pieces. There are three valid options:
 
   \itemize{
-   \item "warn" (the default): emit a waring and drop extra values.
+   \item "warn" (the default): emit a warning and drop extra values.
    \item "drop": drop any extra values without a warning.
    \item "merge": only splits at most \code{length(into)} times
   }}
@@ -44,7 +44,7 @@ columns are integer, numeric or logical.}
   happens when there are not enough pieces. There are three valid options:
 
   \itemize{
-   \item "warn" (the default): emit a waring and fill from the right
+   \item "warn" (the default): emit a warning and fill from the right
    \item "right": fill with missing values on the right
    \item "left": fill with missing values on the left
   }}

--- a/man/spread.Rd
+++ b/man/spread.Rd
@@ -11,19 +11,20 @@ spread(data, key, value, fill = NA, convert = FALSE, drop = TRUE)
 
 \item{key,value}{Bare (unquoted) names of key and value columns.}
 
-\item{fill}{If set, missing values will be replaced with this value.
-Note that there are two types of missingness in the input: explicit
-missing values (i.e. \code{NA}), and implicit missings, rows that
-simply aren't present. Both types of missing value will be replaced by
-\code{fill}.}
+\item{fill}{If set, missing values will be replaced with this value. Note
+that there are two types of missingness in the input: explicit missing
+values (i.e. \code{NA}), and implicit missings, rows that simply aren't
+present. Both types of missing value will be replaced by \code{fill}.}
 
-\item{convert}{If \code{TRUE}, \code{\link{type.convert}} with
-\code{asis = TRUE} will be run on each of the new columns. This is
-useful if the value column was a mix of variables that was coerced to
-a string.}
+\item{convert}{If \code{TRUE}, \code{\link{type.convert}} with \code{asis =
+TRUE} will be run on each of the new columns. This is useful if the value
+column was a mix of variables that was coerced to a string. If the class of
+the value column was factor or date, note that will not be true of the new
+columns that are produced, which are coerced to character before type
+conversion.}
 
-\item{drop}{If \code{FALSE}, will keep factor levels that don't appear
-in the data, filling in missing combinations with \code{fill}.}
+\item{drop}{If \code{FALSE}, will keep factor levels that don't appear in the
+data, filling in missing combinations with \code{fill}.}
 }
 \description{
 Spread a key-value pair across multiple columns.
@@ -43,5 +44,12 @@ stocksm \%>\% spread(time, price)
 # Spread and gather are complements
 df <- data.frame(x = c("a", "b"), y = c(3, 4), z = c(5, 6))
 df \%>\% spread(x, y) \%>\% gather(x, y, a:b, na.rm = TRUE)
+
+# Use 'convert = TRUE' to produce variables of mixed type
+df <- data.frame(row = rep(c(1, 51), each = 3),
+                 var = c("Sepal.Length", "Species", "Species_num"),
+                 value = c(5.1, "setosa", 1, 7.0, "versicolor", 2))
+df \%>\% spread(var, value) \%>\% str
+df \%>\% spread(var, value, convert = TRUE) \%>\% str
 }
 

--- a/man/spread_.Rd
+++ b/man/spread_.Rd
@@ -11,19 +11,20 @@ spread_(data, key_col, value_col, fill = NA, convert = FALSE, drop = TRUE)
 
 \item{key_col,value_col}{Strings giving names of key and value cols.}
 
-\item{fill}{If set, missing values will be replaced with this value.
-Note that there are two types of missingness in the input: explicit
-missing values (i.e. \code{NA}), and implicit missings, rows that
-simply aren't present. Both types of missing value will be replaced by
-\code{fill}.}
+\item{fill}{If set, missing values will be replaced with this value. Note
+that there are two types of missingness in the input: explicit missing
+values (i.e. \code{NA}), and implicit missings, rows that simply aren't
+present. Both types of missing value will be replaced by \code{fill}.}
 
-\item{convert}{If \code{TRUE}, \code{\link{type.convert}} with
-\code{asis = TRUE} will be run on each of the new columns. This is
-useful if the value column was a mix of variables that was coerced to
-a string.}
+\item{convert}{If \code{TRUE}, \code{\link{type.convert}} with \code{asis =
+TRUE} will be run on each of the new columns. This is useful if the value
+column was a mix of variables that was coerced to a string. If the class of
+the value column was factor or date, note that will not be true of the new
+columns that are produced, which are coerced to character before type
+conversion.}
 
-\item{drop}{If \code{FALSE}, will keep factor levels that don't appear
-in the data, filling in missing combinations with \code{fill}.}
+\item{drop}{If \code{FALSE}, will keep factor levels that don't appear in the
+data, filling in missing combinations with \code{fill}.}
 }
 \description{
 This is a S3 generic.

--- a/tests/testthat/test-spread.R
+++ b/tests/testthat/test-spread.R
@@ -35,11 +35,16 @@ test_that("factors are spread into columns (#35)", {
     y = c("c", "d", "c", "d"),
     z = c("w", "x", "y", "z")
   )
+
   out <- data %>% spread(x, z)
   expect_equal(names(out), c("y", "a", "b"))
   expect_true(all(vapply(out, is.factor, logical(1))))
   expect_identical(levels(out$a), c("w", "x"))
   expect_identical(levels(out$b), c("y", "z"))
+
+  out <- data %>% spread(x, z, drop = FALSE)
+  expect_identical(levels(out$a), levels(data$z))
+  expect_identical(levels(out$b), levels(data$z))
 })
 
 test_that("drop = FALSE keeps missing combinations (#25)", {
@@ -90,6 +95,27 @@ test_that("spread can produce mixed variable types (#118)", {
   out <- spread(df, column, cell_contents, convert = TRUE)
   expect_equivalent(vapply(out, class, ""),
                     c("integer", "character", "numeric", "integer"))
+})
+
+test_that("factors can be used with convert = TRUE to produce mixed types", {
+  df <- data.frame(row = c(1, 2, 1, 2, 1, 2),
+                   column = c("f", "f", "g", "g", "h", "h"),
+                   contents = c("aa", "bb", "1", "2", "TRUE", "FALSE"),
+                   stringsAsFactors = FALSE)
+  out <- df %>% spread(column, contents, convert = TRUE)
+  expect_is(out$f, "character")
+  expect_is(out$g, "integer")
+  expect_is(out$h, "logical")
+})
+
+test_that("dates can be used with convert = TRUE", {
+  df <- data.frame(id = c("a", "a", "b", "b"),
+                   key = c("begin", "end", "begin", "end"),
+                   date = Sys.Date() + 0:3,
+                   stringsAsFactors=FALSE)
+  out <- spread(df, key, date, convert = TRUE)
+  expect_is(out$begin, "character")
+  expect_is(out$end, "character")
 })
 
 test_that("vars that are all NA are logical if convert = TRUE (#118)", {

--- a/tests/testthat/test-spread.R
+++ b/tests/testthat/test-spread.R
@@ -39,12 +39,9 @@ test_that("factors are spread into columns (#35)", {
   out <- data %>% spread(x, z)
   expect_equal(names(out), c("y", "a", "b"))
   expect_true(all(vapply(out, is.factor, logical(1))))
-  expect_identical(levels(out$a), c("w", "x"))
-  expect_identical(levels(out$b), c("y", "z"))
-
-  out <- data %>% spread(x, z, drop = FALSE)
   expect_identical(levels(out$a), levels(data$z))
   expect_identical(levels(out$b), levels(data$z))
+
 })
 
 test_that("drop = FALSE keeps missing combinations (#25)", {


### PR DESCRIPTION
Restores `spread()`s ability to create mixed variable types and behaves well when spreading dates and factors. Are there more exotic things I should be worried about?