### PR TITLE
Change order in unite

### DIFF
--- a/R/unite.R
+++ b/R/unite.R
@@ -44,13 +44,14 @@ unite_.data.frame <- function(data, col, from, sep = "_", remove = TRUE) {
   united <- do.call("paste", c(data[from], list(sep = sep)))
 
   first_col <- which(names(data) %in% from)[1]
-  data2 <- append_col(data, united, col, after = first_col - 1)
 
+  data2 <- data
   if (remove) {
     data2 <- data2[setdiff(names(data2), from)]
   }
 
-  data2
+
+  append_col(data2, united, col, after = first_col - 1)
 }
 
 #' @export

--- a/tests/testthat/test-unite.R
+++ b/tests/testthat/test-unite.R
@@ -7,3 +7,11 @@ test_that("unite pastes columns together & removes old col", {
   expect_equal(names(out), "z")
   expect_equal(out$z, "a_b")
 })
+
+test_that("unite does not remove new col in case of name clash", {
+  df <- dplyr::data_frame(x = "a", y = "b")
+  out <- unite(df, x, x:y)
+
+  expect_equal(names(out), "x")
+  expect_equal(out$x, "a_b")
+})


### PR DESCRIPTION
First remove old columns, then add new. With test.

Fixes #89. CC @theunis