### PR TITLE
Cleanup for separate() and spread()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,8 @@
 
 * `unite()` now removes old columns before adding new (#89, @krlmlr).
 
+* `separate()` now warns if defunct ... argument is used (#151, @krlmlr).
+
 # tidyr 0.3.1
 
 * Fixed bug where attributes of non-gather columns were lost (#104)

--- a/R/separate.R
+++ b/R/separate.R
@@ -119,9 +119,9 @@ separate_.tbl_df <- function(data, col, into, sep = "[^[:alnum:]]+",
 }
 
 #' @export
-separate_.tbl_df <- function(data, col, into, sep = "[^[:alnum:]]+",
-                             remove = TRUE, convert = FALSE,
-                             extra = "warn", fill = "warn", ...) {
+separate_.grouped_df <- function(data, col, into, sep = "[^[:alnum:]]+",
+                                 remove = TRUE, convert = FALSE,
+                                 extra = "warn", fill = "warn", ...) {
   dplyr::grouped_df(NextMethod(), dplyr::groups(data))
 }
 

--- a/R/separate.R
+++ b/R/separate.R
@@ -71,8 +71,7 @@ separate <- function(data, col, into, sep = "[^[:alnum:]]+", remove = TRUE,
 #' @param convert If \code{TRUE}, will run \code{\link{type.convert}} with
 #'   \code{as.is = TRUE} on new columns. This is useful if the component
 #'   columns are integer, numeric or logical.
-#' @param ... Other arguments passed on to \code{\link{strsplit}} to control
-#'   how the regular expression is processed.
+#' @param ... Defunct, will be removed in the next version of the package.
 #' @keywords internal
 #' @export
 separate_ <- function(data, col, into, sep = "[^[:alnum:]]+", remove = TRUE,
@@ -86,6 +85,10 @@ separate_.data.frame <- function(data, col, into, sep = "[^[:alnum:]]+",
                                  extra = "warn", fill = "warn", ...) {
   stopifnot(is.character(col), length(col) == 1)
   value <- as.character(data[[col]])
+
+  if (length(list(...)) != 0) {
+    warning("Using ... for passing arguments to strsplit is defunct.")
+  }
 
   if (is.numeric(sep)) {
     l <- strsep(value, sep)

--- a/R/spread.R
+++ b/R/spread.R
@@ -137,8 +137,8 @@ spread_.tbl_df <- function(data, key_col, value_col, fill = NA,
 }
 
 #' @export
-spread_.tbl_df <- function(data, key_col, value_col, fill = NA,
-                           convert = FALSE, drop = TRUE) {
+spread_.grouped_df <- function(data, key_col, value_col, fill = NA,
+                               convert = FALSE, drop = TRUE) {
   regroup(data, NextMethod(), except = c(key_col, value_col))
 }
 

--- a/man/separate.Rd
+++ b/man/separate.Rd
@@ -49,8 +49,7 @@ columns are integer, numeric or logical.}
    \item "left": fill with missing values on the left
   }}
 
-\item{...}{Other arguments passed on to \code{\link{strsplit}} to control
-how the regular expression is processed.}
+\item{...}{Defunct, will be removed in the next version of the package.}
 }
 \description{
 Given either regular expression or a vector of character positions,

--- a/man/separate_.Rd
+++ b/man/separate_.Rd
@@ -49,8 +49,7 @@ columns are integer, numeric or logical.}
    \item "left": fill with missing values on the left
   }}
 
-\item{...}{Other arguments passed on to \code{\link{strsplit}} to control
-how the regular expression is processed.}
+\item{...}{Defunct, will be removed in the next version of the package.}
 }
 \description{
 This is a S3 generic.


### PR DESCRIPTION
- Warn when using defunct ... argument to separate()
- Declare methods for "grouped_df" class