### PR TITLE
Fix nest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr 0.4.0.9000
 
+* Fixed bug in `nest()` where nested data was ending up in the wrong row (#158).
+
 # tidyr 0.4.0
 
 ## Nested data frames

--- a/R/nest.R
+++ b/R/nest.R
@@ -72,7 +72,7 @@ nest_impl <- function(data, key_col, group_cols, nest_cols) {
   out <- dplyr::distinct_(dplyr::select_(data, .dots = group_cols))
 
   idx <- dplyr::group_indices_(data, .dots = group_cols)
-  out[[key_col]] <- unname(split(data[nest_cols], idx))
+  out[[key_col]] <- unname(split(data[nest_cols], idx))[order(unique(idx))]
 
   out
 }

--- a/R/nest.R
+++ b/R/nest.R
@@ -72,7 +72,7 @@ nest_impl <- function(data, key_col, group_cols, nest_cols) {
   out <- dplyr::distinct_(dplyr::select_(data, .dots = group_cols))
 
   idx <- dplyr::group_indices_(data, .dots = group_cols)
-  out[[key_col]] <- unname(split(data[nest_cols], idx))[order(unique(idx))]
+  out[[key_col]] <- unname(split(data[nest_cols], idx))[unique(idx)]
 
   out
 }

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -29,3 +29,10 @@ test_that("can restrict variables in grouped nest", {
   expect_equal(names(out$data[[1]]), "y")
 })
 
+test_that("puts data into the correct row", {
+  df <- dplyr::data_frame(x = 1:3, y = c("B", "A", "A"))
+  out <- nest(df, x) %>%
+    dplyr::filter(y == "B")
+
+  expect_equal(out$data[[1]]$x, 1)
+})


### PR DESCRIPTION
Seem to be getting some unexpected behavior in `nest`:

```r
df <- data.frame(x = 1:3, y = c("B", "A", "A"))
tidyr::nest(df, x)
#      y data   
# 1    B 2, 3
# 2    A    1
```

Made a small change to `nest_impl`, and added a unit test. 