### PR TITLE
Allow replace_na replacements to be given in the ... args

### DIFF
--- a/R/replace_na.R
+++ b/R/replace_na.R
@@ -1,13 +1,34 @@
 #' Replace missing values
 #'
+#' Replace missing values in columns, either with a specific replacement
+#' value or with a value (or expression) based on other columns in the
+#' data.
+#'
 #' @param data A data frame.
 #' @param replace A named list given the value to replace \code{NA} with
 #'   for each column.
-#' @param ... Additional arguments for methods. Currently unused.
+#' @param ... Named arguments providing values to replace \code{NA} with
+#' for each column, or an expression based on other columns
+#'
+#' Note that if you are replacing a column named \code{replace}
+#' you need to use replace = list(replace = 0) argument rather than a named
+#' argument. This is to keep \code{replace_na} backwards-compatible.
+#'
 #' @examples
 #' library(dplyr)
 #' df <- data_frame(x = c(1, 2, NA), y = c("a", NA, "b"))
+#'
+#' # can be given as arguments or a list
+#' df %>% replace_na(x = 0, y = "unknown")
 #' df %>% replace_na(list(x = 0, y = "unknown"))
+#'
+#' # can replace columns with other columns
+#' df <- data_frame(x = c(1, 2, NA), y = c(3, NA, 4))
+#' df %>% replace_na(x = y)
+#' df %>% replace_na(y = x)
+#'
+#' df %>% replace_na(x = y * 10)
+#'
 #' @export
 replace_na <- function(data, replace = list(), ...) {
   UseMethod("replace_na")
@@ -17,8 +38,19 @@ replace_na <- function(data, replace = list(), ...) {
 replace_na.data.frame <- function(data, replace = list(), ...) {
   stopifnot(is.list(replace))
 
+  dots <- lazyeval::lazy_dots(...)
+  replace <- c(replace, lazyeval::lazy_eval(dots, data = data))
+
   for (var in names(replace)) {
-    data[[var]][is.na(data[[var]])] <- replace[[var]]
+    repl <- replace[[var]]
+    nas <- is.na(data[[var]])
+
+    if (length(repl) == nrow(data)) {
+      # replacing with another column
+      repl <- repl[nas]
+    }
+
+    data[[var]][nas] <- repl
   }
 
   data

--- a/man/replace_na.Rd
+++ b/man/replace_na.Rd
@@ -12,14 +12,32 @@ replace_na(data, replace = list(), ...)
 \item{replace}{A named list given the value to replace \code{NA} with
 for each column.}
 
-\item{...}{Additional arguments for methods. Currently unused.}
+\item{...}{Named arguments providing values to replace \code{NA} with
+for each column, or an expression based on other columns
+
+Note that if you are replacing a column named \code{replace}
+you need to use replace = list(replace = 0) argument rather than a named
+argument. This is to keep \code{replace_na} backwards-compatible.}
 }
 \description{
-Replace missing values
+Replace missing values in columns, either with a specific replacement
+value or with a value (or expression) based on other columns in the
+data.
 }
 \examples{
 library(dplyr)
 df <- data_frame(x = c(1, 2, NA), y = c("a", NA, "b"))
+
+# can be given as arguments or a list
+df \%>\% replace_na(x = 0, y = "unknown")
 df \%>\% replace_na(list(x = 0, y = "unknown"))
+
+# can replace columns with other columns
+df <- data_frame(x = c(1, 2, NA), y = c(3, NA, 4))
+df \%>\% replace_na(x = y)
+df \%>\% replace_na(y = x)
+
+df \%>\% replace_na(x = y * 10)
+
 }
 

--- a/tests/testthat/test-replace_na.R
+++ b/tests/testthat/test-replace_na.R
@@ -12,4 +12,31 @@ test_that("missing values are replaced", {
   out <- replace_na(df, list(x = 0))
 
   expect_equal(out$x, c(1, 0))
+
+  out2 <- replace_na(df, x = 0)
+  expect_equal(out2$x, c(1, 0))
+})
+
+test_that("columns can be replaced with other columns or expressions", {
+  df <- dplyr::data_frame(x = c(1, 2, NA), y = c(3, NA, 4))
+
+  out <- replace_na(df, x = y)
+  expect_equal(out$x, c(1, 2, 4))
+  expect_equal(df$y, out$y)
+
+  out <- replace_na(df, y = x)
+  expect_equal(out$y, c(3, 2, 4))
+  expect_equal(df$x, out$x)
+
+  out <- replace_na(df, x = y, y = x)
+  expect_equal(out$x, c(1, 2, 4))
+  expect_equal(out$y, c(3, 2, 4))
+})
+
+test_that("columns can be replaced with expressions", {
+  df <- dplyr::data_frame(x = c(1, 2, NA), y = c(3, NA, 4))
+
+  out <- replace_na(df, x = y * 2)
+  expect_equal(out$x, c(1, 2, 8))
+  expect_equal(df$y, out$y)
 })


### PR DESCRIPTION
Allow replace_na replacements to be given as

```r
replace_na(data, x = 0, y = "unknown")
```

along with allowing the original behavior of

```r
replace_na(data, list(x = 0, y = "unknown"))
```

Also allows NSE evaluation to replace one NAs in one column with another column:

```r
df <- data.frame(x = c(1, 2, NA), y = c(3, NA, 4))
replace_na(df, x = y)
```
It's backwards compatible, ... wasn't being used. Includes additional test cases and examples.