### PR TITLE
Fixes #170, regarding order of separate columns when fill = "left".

### DIFF
--- a/src/simplifyPieces.cpp
+++ b/src/simplifyPieces.cpp
@@ -27,9 +27,13 @@ List simplifyPieces(ListOf<CharacterVector> pieces, int p,
     } else if (x.size() < p) { // too small
       tooSml.push_back(i + 1);
 
+      int gap = p - x.size();
       for (int j = 0; j < p; ++j) {
-        int idx = fillLeft ? p - j - 1 : j;
-        out[idx][i] = (j < x.size()) ? x[j] : NA_STRING;
+        if (fillLeft) {
+          out[j][i] = (j >= gap) ? x[j - gap] : NA_STRING;
+        } else {
+          out[j][i] = (j < x.size()) ? x[j] : NA_STRING;
+        }
       }
 
     } else {

--- a/tests/testthat/test-separate.R
+++ b/tests/testthat/test-separate.R
@@ -52,6 +52,8 @@ test_that("too few pieces dealt with as requested", {
 
   left <- separate(df, x, c("x", "y", "z"), fill = "left")
   expect_equal(left$x, c(NA, "a"))
+  expect_equal(left$y, c("a", "b"))
+  expect_equal(left$z, c("b", "c"))
 
   right <- separate(df, x, c("x", "y", "z"), fill = "right")
   expect_equal(right$z, c(NA, "c"))
@@ -64,3 +66,4 @@ test_that("preserves grouping", {
   expect_equal(class(df), class(rs))
   expect_equal(dplyr::groups(df), dplyr::groups(rs))
 })
+


### PR DESCRIPTION
Fixes #170, regarding order of separate columns when fill = "left".

Added test case for this situation