### PR TITLE
change right_join to full_join in expand docs

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -70,9 +70,9 @@
 #' # We can use anti_join to figure out which observations are missing
 #' all %>% anti_join(experiment)
 #'
-#' # And use right_join to add in the appropriate missing values to the
+#' # And use full_join to add in the appropriate missing values to the
 #' # original data
-#' all %>% right_join(experiment)
+#' all %>% full_join(experiment)
 #' # Or use the complete() short-hand
 #' experiment %>% complete(nesting(name, trt), rep)
 expand <- function(data, ...) {


### PR DESCRIPTION
In the expand documentation I believe full_join was meant instead of right_join.