### PR TITLE
Changed deprecation message of `extract_numeric()` to point to `readr…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr 0.6.0.9000
 
+* Changed deprecation message of `extract_numeric()` to point to `readr::parse_number()` rather than `readr::parse_numeric()`
+
 # tidyr 0.6.0
 
 ## API changes

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,12 +24,12 @@ compact <- function(x) x[vapply(x, length, integer(1)) > 0]
 
 #' Extract numeric component of variable.
 #'
-#' DEPRECATED: please use \code{readr::parse_numeric()} instead.
+#' DEPRECATED: please use \code{readr::parse_number()} instead.
 #'
 #' @param x A character vector (or a factor).
 #' @export
 extract_numeric <- function(x) {
-  message("extract_numeric() is deprecated: please use readr::parse_numeric() instead")
+  message("extract_numeric() is deprecated: please use readr::parse_number() instead")
   as.numeric(gsub("[^0-9.-]+", "", as.character(x)))
 }
 


### PR DESCRIPTION
Changed deprecation message of `extract_numeric()` to point to `readr::parse_number()` rather than `readr::parse_numeric()`