### PR TITLE
Add `by` to `chop()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `chop()` gains a `by` argument for specifying grouping columns, similar to `nest(.by =)` (@hrryt, #1490).
 
+* Specifying `chop()`'s `cols` argument by position is soft-deprecated. It must instead be specified by name, which better communicates intent now that `chop()` also has a `by` argument (#1490).
+
 # tidyr 1.3.2
 
 * `fill()` gains a `.by` argument as an alternative to `dplyr::group_by()` for

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr (development version)
 
+* `chop()` gains a `by` argument for specifying grouping columns, similar to `nest(.by =)` (@hrryt, #1490).
+
 # tidyr 1.3.2
 
 * `fill()` gains a `.by` argument as an alternative to `dplyr::group_by()` for

--- a/R/chop.R
+++ b/R/chop.R
@@ -126,7 +126,7 @@ chop_info <- function(
   cols_is_null <- quo_is_null(cols)
   by_is_null <- quo_is_null(by)
 
-  if(cols_is_null && by_is_null) {
+  if (cols_is_null && by_is_null) {
     stop_use_cols_or_by(error_call = error_call)
   }
 

--- a/R/chop.R
+++ b/R/chop.R
@@ -124,18 +124,20 @@
 #' df |> unchop(y, keep_empty = TRUE)
 chop <- function(
   data,
-  cols = NULL,
   ...,
+  cols = NULL,
   by = NULL,
   error_call = current_env()
 ) {
-  check_dots_empty0(...)
   check_data_frame(data, call = error_call)
+
+  cols <- compat_chop_cols(cols = enquo(cols), ...)
+  by <- enquo(by)
 
   info <- chop_info(
     data,
-    cols = {{ cols }},
-    by = {{ by }},
+    cols = !!cols,
+    by = !!by,
     error_call = error_call
   )
   cols <- info$cols
@@ -236,6 +238,49 @@ col_chop <- function(x, indices) {
   out <- new_list_of(out, ptype)
 
   out
+}
+
+compat_chop_cols <- function(cols, ...) {
+  n_dots <- dots_n(...)
+
+  if (n_dots == 0L) {
+    return(cols)
+  }
+
+  # `env` and `user_env` here are fixed to always report `chop()` as `env`
+  # and the caller of `chop()` as `user_env`, regardless of the `error_call`
+  # argument. We think that makes the most sense for these errors/warnings.
+  env <- caller_env()
+  user_env <- caller_env(2)
+
+  if (n_dots != 1L) {
+    check_dots_empty0(..., call = env)
+  }
+
+  if (!quo_is_null(cols)) {
+    cli::cli_abort(
+      "Can't specify `cols` by both name and position.",
+      call = env
+    )
+  }
+
+  # Safe, we checked `n_dots == 1L` above
+  cols <- enquos(...)[[1L]]
+
+  lifecycle::deprecate_soft(
+    when = "1.4.0",
+    what = I(cli::format_inline(
+      "Specifying the {.arg cols} argument by position"
+    )),
+    details = cli::format_inline(
+      "Please explicitly name {.arg cols}, like {.code chop(data, cols = {as_label(cols)})}."
+    ),
+    env = env,
+    user_env = user_env,
+    id = "tidyr-chop-positional-cols"
+  )
+
+  cols
 }
 
 #' @export

--- a/R/chop.R
+++ b/R/chop.R
@@ -2,17 +2,16 @@
 #'
 #' @description
 #' Chopping and unchopping preserve the width of a data frame, changing its
-#' length. `chop()` makes `df` shorter by converting rows within each group
-#' into list-columns. `unchop()` makes `df` longer by expanding list-columns
+#' length. `chop()` makes `data` shorter by converting rows within each group
+#' into list-columns. `unchop()` makes `data` longer by expanding list-columns
 #' so that each element of the list-column gets its own row in the output.
+#'
 #' `chop()` and `unchop()` are building blocks for more complicated functions
-#' (like [unnest()], [unnest_longer()], and [unnest_wider()]) and are generally
-#' more suitable for programming than interactive data analysis.
+#' (like [unnest()], [unnest_longer()], and [unnest_wider()]).
 #'
 #' @details
-#' Generally, unchopping is more useful than chopping because it simplifies
-#' a complex data structure, and [nest()]ing is usually more appropriate
-#' than `chop()`ing since it better preserves the connections between
+#' When multiple columns are being chopped at once, [nest()] is usually more
+#' appropriate than `chop()` since it better preserves the connections between
 #' observations.
 #'
 #' `chop()` creates list-columns of class [vctrs::list_of()] to ensure
@@ -21,6 +20,25 @@
 #' the roundtrip chop and unchop. Because `<list_of>` keeps tracks of
 #' the type of its elements, `unchop()` is able to reconstitute the
 #' correct vector type even for empty list-columns.
+#'
+#' @section Connection to `split()`:
+#'
+#' `chop()` is the tidyverse version of [base::split()], with a few key changes:
+#'
+#' - The unique values of the columns used to chop by are preserved losslessly
+#'   as output columns, rather than being converted to character labels used as
+#'   names on the output list. This is particularly useful when chopping by
+#'   multiple columns.
+#'
+#' - Multiple columns can be chopped at once, producing one list-column per
+#'   chopped column. The closest `split()` equivalent is to split a data frame,
+#'   which produces a result more similar to [nest()] than `chop()`.
+#'
+#' - When chopping by multiple columns, the [interaction()]s of those columns
+#'   are not taken, and missing values are not dropped, which avoids a quadratic
+#'   runtime and tends to produce more expected results in practice.
+#'
+#' For an even lower-level version, see [vctrs::vec_split()].
 #'
 #' @inheritParams rlang::args_dots_empty
 #' @inheritParams rlang::args_error_context
@@ -52,36 +70,49 @@
 #' @export
 #' @examples
 #' # Chop ----------------------------------------------------------------------
-#' df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
-#' # Note that we get one row of output for each unique combination of
-#' # non-chopped variables
-#' df |> chop(c(y, z))
-#' # Compare to `nest()`
-#' df |> nest(data = c(y, z))
+#' df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = c(1, 1, 2, 3, 3, 4), z = 1:6)
 #'
-#' # Specify variables to chop by (rather than variables to chop) using `by`
-#' df |> chop(by = x)
-#' # Compare to `nest()`
-#' df |> nest(.by = x)
+#' # `chop()` is most useful as a tidyverse alternative to `base::split()`
+#'
+#' # Chop `z` by `x` and `y`. Note that we get one row of output for each unique
+#' # combination of non-chopped variables.
+#' df |> chop(z)
+#'
+#' # Equivalently, specify variables to chop by (rather than variables to chop)
+#' # using `by`
+#' df |> chop(by = c(x, y))
+#'
+#' # Compare to `split()`, notice how `x` and `y` are converted to character
+#' # labels
+#' df |> split(df[c("x", "y")], drop = TRUE)
 #'
 #' # `cols` and `by` can be used together to drop columns you no longer need.
-#' # This drops `z`:
-#' df |> chop(cols = y, by = x)
+#' # This drops `y`:
+#' df |> chop(z, by = x)
 #'
 #' # You cannot chop a column you are also trying to chop by
 #' try(df |> chop(cols = x, by = x))
+#'
+#' # Multiple columns can be chopped at once, producing one list-column per
+#' # chopped column
+#' df |> chop(by = x)
+#' # Compare to `nest()`, which keeps the chopped `y` and `z` columns together
+#' # in nested data frames
+#' df |> nest(.by = x)
+#' # `split()` is more similar to `nest()` here
+#' split(df[c("y", "z")], df["x"])
 #'
 #' # Unchop --------------------------------------------------------------------
 #' df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))
 #' df |> unchop(y)
 #' df |> unchop(y, keep_empty = TRUE)
 #'
-#' # unchop will error if the types are not compatible:
+#' # `unchop()` will error if the types are not compatible:
 #' df <- tibble(x = 1:2, y = list("1", 1:3))
 #' try(df |> unchop(y))
 #'
 #' # Unchopping a list-col of data frames must generate a df-col because
-#' # unchop leaves the column names unchanged
+#' # `unchop()` leaves the column names unchanged
 #' df <- tibble(x = 1:3, y = list(NULL, tibble(x = 1), tibble(y = 1:2)))
 #' df |> unchop(y)
 #' df |> unchop(y, keep_empty = TRUE)

--- a/R/chop.R
+++ b/R/chop.R
@@ -150,17 +150,28 @@ chop_info <- function(data, cols, by, error_call) {
 
   if (has_cols) {
     # Remove `by` names before evaluating `cols`. This:
-    # - Avoids double selection like `chop(cols = x, by = x)`
-    # - Enables a meaningful `chop(cols = everything(), by = x)`
+    # - Avoids double selection like `chop(cols = x, by = x)`, which would cause
+    #   name collisions otherwise.
+    # - Enables a meaningful `chop(cols = everything(), by = x)`.
     # Consistent with `pivot_wider(id_cols = )`.
-
-    # TODO!: Improve on error with rethrow after rebase on main
-    cols <- names(tidyselect::eval_select(
-      expr = cols,
-      data = data[setdiff(names, by)],
-      allow_rename = FALSE,
-      error_call = error_call
-    ))
+    try_fetch(
+      cols <- names(tidyselect::eval_select(
+        expr = cols,
+        data = data[setdiff(names, by)],
+        allow_rename = FALSE,
+        error_call = error_call
+      )),
+      vctrs_error_subscript_oob = function(cnd) {
+        maybe_throw_already_selected_error(
+          cnd[["i"]],
+          "cols",
+          by,
+          "by",
+          error_call
+        )
+        zap()
+      }
+    )
   } else {
     cols <- character()
   }

--- a/R/chop.R
+++ b/R/chop.R
@@ -45,19 +45,25 @@
 #' @inheritParams rlang::args_error_context
 #'
 #' @param data A data frame.
-#' @param cols <[`tidy-select`][tidyr_tidy_select]> Columns to chop or unchop.
+#' @param cols,by <[`tidy-select`][tidyr_tidy_select]> Column selectors.
 #'
-#'   For `chop()`, columns specified by `by` are removed from `data` before
-#'   evaluating `cols`. If not supplied, `cols` is derived as all columns _not_
-#'   selected by `by`. At least one of `cols` and `by` must be specified.
+#'   For `chop()`:
 #'
-#'   For `unchop()`, each column should be a list-column containing generalised
-#'   vectors (e.g. any mix of `NULL`s, atomic vector, S3 vectors, a lists,
-#'   or data frames).
-#' @param by <[`tidy-select`][tidyr_tidy_select]> Columns to chop _by_.
+#'   - `by` selects columns to chop by. If not specified, will be derived as
+#'     all columns not selected by `cols`.
 #'
-#'   If not supplied, then `by` is derived as all columns _not_ selected by
-#'   `cols`. At least one of `cols` and `by` must be specified.
+#'   - `cols` selects columns to chop. If not specified, will be derived as all
+#'     columns not selected by `by`.
+#'
+#'   Specifying both `by` and `cols` drops all unselected columns in `data` from
+#'   the output. Note that columns selected by `by` are removed from `data`
+#'   before evaluating `cols`.
+#'
+#'   At least one of `by` or `cols` must be specified.
+#'
+#'   For `unchop()`, `cols` selects columns to unchop. Each column should be a
+#'   list-column containing generalised vectors (e.g. any mix of `NULL`s, atomic
+#'   vectors, S3 vectors, lists, or data frames).
 #' @param keep_empty By default, you get one row of output for each element
 #'   of the list that you are unchopping/unnesting. This means that if there's a
 #'   size-0 element (like `NULL` or an empty data frame or vector), then that

--- a/R/chop.R
+++ b/R/chop.R
@@ -60,16 +60,16 @@
 #' df |> nest(data = c(y, z))
 #'
 #' # Specify variables to chop by (rather than variables to chop) using `by`
-#' df %>% chop(by = x)
+#' df |> chop(by = x)
 #' # Compare to `nest()`
-#' df %>% nest(.by = x)
+#' df |> nest(.by = x)
 #'
 #' # `cols` and `by` can be used together to drop columns you no longer need.
 #' # This drops `z`:
-#' df %>% chop(cols = y, by = x)
+#' df |> chop(cols = y, by = x)
 #'
 #' # You cannot chop a column you are also trying to chop by
-#' try(df %>% chop(cols = x, by = x))
+#' try(df |> chop(cols = x, by = x))
 #'
 #' # Unchop --------------------------------------------------------------------
 #' df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))

--- a/R/chop.R
+++ b/R/chop.R
@@ -28,20 +28,17 @@
 #' @param data A data frame.
 #' @param cols <[`tidy-select`][tidyr_tidy_select]> Columns to chop or unchop.
 #'
-#'   If not supplied for `chop()`, then `cols` is derived as all columns _not_
-#'   selected by `by`.
+#'   For `chop()`, columns specified by `by` are removed from `data` before
+#'   evaluating `cols`. If not supplied, `cols` is derived as all columns _not_
+#'   selected by `by`. At least one of `cols` and `by` must be specified.
 #'
 #'   For `unchop()`, each column should be a list-column containing generalised
 #'   vectors (e.g. any mix of `NULL`s, atomic vector, S3 vectors, a lists,
 #'   or data frames).
-#' @param by <[`tidy-select`][tidyr_tidy_select]> Columns to chop _by_; these
-#'   will not be chopped.
-#'
-#'   `by` can be used in place of or in conjunction with columns supplied
-#'   through `cols`.
+#' @param by <[`tidy-select`][tidyr_tidy_select]> Columns to chop _by_.
 #'
 #'   If not supplied, then `by` is derived as all columns _not_ selected by
-#'   `cols`.
+#'   `cols`. At least one of `cols` and `by` must be specified.
 #' @param keep_empty By default, you get one row of output for each element
 #'   of the list that you are unchopping/unnesting. This means that if there's a
 #'   size-0 element (like `NULL` or an empty data frame or vector), then that
@@ -59,21 +56,20 @@
 #' # Note that we get one row of output for each unique combination of
 #' # non-chopped variables
 #' df |> chop(c(y, z))
-#' # cf nest
+#' # Compare to `nest()`
 #' df |> nest(data = c(y, z))
 #'
 #' # Specify variables to chop by (rather than variables to chop) using `by`
 #' df %>% chop(by = x)
+#' # Compare to `nest()`
+#' df %>% nest(.by = x)
 #'
-#' # Use tidyselect syntax and helpers, just like in `dplyr::select()`
-#' df %>% chop(any_of(c("y", "z")))
-#'
-#' # `cols` and `by` can be used together to drop columns you no longer need,
-#' # or to chop the columns you are chopping by too.
+#' # `cols` and `by` can be used together to drop columns you no longer need.
 #' # This drops `z`:
-#' df %>% chop(y, by = x)
-#' # This includes `x` in the chopped columns:
-#' df %>% chop(everything(), by = x)
+#' df %>% chop(cols = y, by = x)
+#'
+#' # You cannot chop a column you are also trying to chop by
+#' try(df %>% chop(cols = x, by = x))
 #'
 #' # Unchop --------------------------------------------------------------------
 #' df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))
@@ -89,11 +85,22 @@
 #' df <- tibble(x = 1:3, y = list(NULL, tibble(x = 1), tibble(y = 1:2)))
 #' df |> unchop(y)
 #' df |> unchop(y, keep_empty = TRUE)
-chop <- function(data, cols = NULL, ..., by = NULL, error_call = current_env()) {
+chop <- function(
+  data,
+  cols = NULL,
+  ...,
+  by = NULL,
+  error_call = current_env()
+) {
   check_dots_empty0(...)
   check_data_frame(data, call = error_call)
 
-  info <- chop_info(data, cols = {{ cols }}, by = {{ by }})
+  info <- chop_info(
+    data,
+    cols = {{ cols }},
+    by = {{ by }},
+    error_call = error_call
+  )
   cols <- info$cols
   by <- info$by
 
@@ -114,44 +121,56 @@ chop <- function(data, cols = NULL, ..., by = NULL, error_call = current_env()) 
   reconstruct_tibble(data, out)
 }
 
-chop_info <- function(
-    data,
-    cols = NULL,
-    by = NULL,
-    error_call = caller_env()
-) {
+chop_info <- function(data, cols, by, error_call) {
   by <- enquo(by)
+  has_by <- !quo_is_null(by)
+
   cols <- enquo(cols)
+  has_cols <- !quo_is_null(cols)
 
-  cols_is_null <- quo_is_null(cols)
-  by_is_null <- quo_is_null(by)
-
-  if (cols_is_null && by_is_null) {
-    stop_use_cols_or_by(error_call = error_call)
+  if (!has_cols && !has_by) {
+    cli::cli_abort(
+      "At least one of {.var cols} or {.var by} must be supplied.",
+      call = error_call
+    )
   }
 
   names <- names(data)
 
-  cols <- names(tidyselect::eval_select(
-    expr = cols,
-    data = data,
-    allow_rename = FALSE,
-    error_call = error_call
-  ))
+  if (has_by) {
+    by <- names(tidyselect::eval_select(
+      expr = by,
+      data = data,
+      allow_rename = FALSE,
+      error_call = error_call
+    ))
+  } else {
+    by <- character()
+  }
 
-  by <- names(tidyselect::eval_select(
-    expr = by,
-    data = data,
-    allow_rename = FALSE,
-    error_call = error_call
-  ))
+  if (has_cols) {
+    # Remove `by` names before evaluating `cols`. This:
+    # - Avoids double selection like `chop(cols = x, by = x)`
+    # - Enables a meaningful `chop(cols = everything(), by = x)`
+    # Consistent with `pivot_wider(id_cols = )`.
 
-  if (cols_is_null) {
+    # TODO!: Improve on error with rethrow after rebase on main
+    cols <- names(tidyselect::eval_select(
+      expr = cols,
+      data = data[setdiff(names, by)],
+      allow_rename = FALSE,
+      error_call = error_call
+    ))
+  } else {
+    cols <- character()
+  }
+
+  if (!has_cols) {
     # Derive `cols` names from `by`
     cols <- setdiff(names, by)
   }
 
-  if (by_is_null) {
+  if (!has_by) {
     # Derive `by` names from `cols`
     by <- setdiff(names, cols)
   }
@@ -160,11 +179,6 @@ chop_info <- function(
     cols = cols,
     by = by
   )
-}
-
-stop_use_cols_or_by <- function(error_call = caller_env()) {
-  message <- c("At least one of {.var cols} or {.var by} must be supplied.")
-  cli::cli_abort(message, call = error_call)
 }
 
 col_chop <- function(x, indices) {

--- a/R/chop.R
+++ b/R/chop.R
@@ -28,15 +28,16 @@
 #' - The unique values of the columns used to chop by are preserved losslessly
 #'   as output columns, rather than being converted to character labels used as
 #'   names on the output list. This is particularly useful when chopping by
-#'   multiple columns.
+#'   non-string columns or multiple columns.
 #'
 #' - Multiple columns can be chopped at once, producing one list-column per
 #'   chopped column. The closest `split()` equivalent is to split a data frame,
 #'   which produces a result more similar to [nest()] than `chop()`.
 #'
-#' - When chopping by multiple columns, the [interaction()]s of those columns
-#'   are not taken, and missing values are not dropped, which avoids a quadratic
-#'   runtime and tends to produce more expected results in practice.
+#' - When chopping by multiple columns, only the combinations present in the
+#'   data are included in the output. This is different from `split()`, which
+#'   takes the [interaction()] of the columns, leading to a potential
+#'   combinatorial explosion of output elements.
 #'
 #' For an even lower-level version, see [vctrs::vec_split()].
 #'
@@ -75,20 +76,19 @@
 #' # `chop()` is most useful as a tidyverse alternative to `base::split()`
 #'
 #' # Chop `z` by `x` and `y`. Note that we get one row of output for each unique
-#' # combination of non-chopped variables.
-#' df |> chop(z)
-#'
-#' # Equivalently, specify variables to chop by (rather than variables to chop)
-#' # using `by`
+#' # combination of variables that we chop by.
 #' df |> chop(by = c(x, y))
 #'
 #' # Compare to `split()`, notice how `x` and `y` are converted to character
 #' # labels
 #' df |> split(df[c("x", "y")], drop = TRUE)
 #'
+#' # Equivalently, specify variables to chop (rather than variables to chop by)
+#' df |> chop(cols = z)
+#'
 #' # `cols` and `by` can be used together to drop columns you no longer need.
 #' # This drops `y`:
-#' df |> chop(z, by = x)
+#' df |> chop(cols = z, by = x)
 #'
 #' # You cannot chop a column you are also trying to chop by
 #' try(df |> chop(cols = x, by = x))

--- a/R/chop.R
+++ b/R/chop.R
@@ -28,9 +28,20 @@
 #' @param data A data frame.
 #' @param cols <[`tidy-select`][tidyr_tidy_select]> Columns to chop or unchop.
 #'
+#'   If not supplied for `chop()`, then `cols` is derived as all columns _not_
+#'   selected by `by`.
+#'
 #'   For `unchop()`, each column should be a list-column containing generalised
 #'   vectors (e.g. any mix of `NULL`s, atomic vector, S3 vectors, a lists,
 #'   or data frames).
+#' @param by <[`tidy-select`][tidyr_tidy_select]> Columns to chop _by_; these
+#'   will not be chopped.
+#'
+#'   `by` can be used in place of or in conjunction with columns supplied
+#'   through `cols`.
+#'
+#'   If not supplied, then `by` is derived as all columns _not_ selected by
+#'   `cols`.
 #' @param keep_empty By default, you get one row of output for each element
 #'   of the list that you are unchopping/unnesting. This means that if there's a
 #'   size-0 element (like `NULL` or an empty data frame or vector), then that
@@ -51,6 +62,19 @@
 #' # cf nest
 #' df |> nest(data = c(y, z))
 #'
+#' # Specify variables to chop by (rather than variables to chop) using `by`
+#' df %>% chop(by = x)
+#'
+#' # Use tidyselect syntax and helpers, just like in `dplyr::select()`
+#' df %>% chop(any_of(c("y", "z")))
+#'
+#' # `cols` and `by` can be used together to drop columns you no longer need,
+#' # or to chop the columns you are chopping by too.
+#' # This drops `z`:
+#' df %>% chop(y, by = x)
+#' # This includes `x` in the chopped columns:
+#' df %>% chop(everything(), by = x)
+#'
 #' # Unchop --------------------------------------------------------------------
 #' df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))
 #' df |> unchop(y)
@@ -65,20 +89,16 @@
 #' df <- tibble(x = 1:3, y = list(NULL, tibble(x = 1), tibble(y = 1:2)))
 #' df |> unchop(y)
 #' df |> unchop(y, keep_empty = TRUE)
-chop <- function(data, cols, ..., error_call = current_env()) {
+chop <- function(data, cols = NULL, ..., by = NULL, error_call = current_env()) {
   check_dots_empty0(...)
   check_data_frame(data, call = error_call)
-  check_required(cols, call = error_call)
 
-  cols <- tidyselect::eval_select(
-    expr = enquo(cols),
-    data = data,
-    allow_rename = FALSE,
-    error_call = error_call
-  )
+  info <- chop_info(data, cols = {{ cols }}, by = {{ by }})
+  cols <- info$cols
+  by <- info$by
 
   cols <- tidyr_new_list(data[cols])
-  keys <- data[setdiff(names(data), names(cols))]
+  keys <- data[by]
 
   info <- vec_group_loc(keys)
   keys <- info$key
@@ -92,6 +112,59 @@ chop <- function(data, cols, ..., error_call = current_env()) {
   out <- vec_cbind(keys, cols, .error_call = error_call)
 
   reconstruct_tibble(data, out)
+}
+
+chop_info <- function(
+    data,
+    cols = NULL,
+    by = NULL,
+    error_call = caller_env()
+) {
+  by <- enquo(by)
+  cols <- enquo(cols)
+
+  cols_is_null <- quo_is_null(cols)
+  by_is_null <- quo_is_null(by)
+
+  if(cols_is_null && by_is_null) {
+    stop_use_cols_or_by(error_call = error_call)
+  }
+
+  names <- names(data)
+
+  cols <- names(tidyselect::eval_select(
+    expr = cols,
+    data = data,
+    allow_rename = FALSE,
+    error_call = error_call
+  ))
+
+  by <- names(tidyselect::eval_select(
+    expr = by,
+    data = data,
+    allow_rename = FALSE,
+    error_call = error_call
+  ))
+
+  if (cols_is_null) {
+    # Derive `cols` names from `by`
+    cols <- setdiff(names, by)
+  }
+
+  if (by_is_null) {
+    # Derive `by` names from `cols`
+    by <- setdiff(names, cols)
+  }
+
+  list(
+    cols = cols,
+    by = by
+  )
+}
+
+stop_use_cols_or_by <- function(error_call = caller_env()) {
+  message <- c("At least one of {.var cols} or {.var by} must be supplied.")
+  cli::cli_abort(message, call = error_call)
 }
 
 col_chop <- function(x, indices) {

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -689,7 +689,7 @@ maybe_throw_already_selected_error <- function(
 stop_already_selected <- function(col, new_arg, old_arg, call) {
   cli::cli_abort(
     c(
-      "{.code {new_arg}} can't select a column already selected by {.code {old_arg}}.",
+      "{.code {new_arg}} can't reference a column already selected by {.code {old_arg}}.",
       i = "Column {.code {col}} has already been selected."
     ),
     parent = NA,

--- a/R/pivot-wide.R
+++ b/R/pivot-wide.R
@@ -643,34 +643,54 @@ select_wider_id_cols <- function(
       error_call = error_call
     ),
     vctrs_error_subscript_oob = function(cnd) {
-      rethrow_id_cols_oob(cnd, names_from_cols, values_from_cols, error_call)
+      maybe_throw_already_selected_error(
+        cnd[["i"]],
+        "id_cols",
+        names_from_cols,
+        "names_from",
+        error_call
+      )
+      maybe_throw_already_selected_error(
+        cnd[["i"]],
+        "id_cols",
+        values_from_cols,
+        "values_from",
+        error_call
+      )
+      zap()
     }
   )
 
   names(id_cols)
 }
 
-rethrow_id_cols_oob <- function(cnd, names_from_cols, values_from_cols, call) {
-  i <- cnd[["i"]]
+maybe_throw_already_selected_error <- function(
+  new_cols,
+  new_arg,
+  old_cols,
+  old_arg,
+  call
+) {
+  if (!is_character(new_cols)) {
+    # Let someone else handle it
+    return()
+  }
 
-  if (is_string(i)) {
-    # Try to throw our custom error
-    if (i %in% names_from_cols) {
-      stop_id_cols_oob(i, "names_from", call = call)
-    } else if (i %in% values_from_cols) {
-      stop_id_cols_oob(i, "values_from", call = call)
+  # Try to throw our custom error
+  for (new_col in new_cols) {
+    if (new_col %in% old_cols) {
+      stop_already_selected(new_col, new_arg, old_arg, call)
     }
   }
 
-  # Otherwise fall through and throw standard tidyselect error
-  zap()
+  # Let someone else handle it
 }
 
-stop_id_cols_oob <- function(i, arg, call) {
+stop_already_selected <- function(col, new_arg, old_arg, call) {
   cli::cli_abort(
     c(
-      "`id_cols` can't select a column already selected by `{arg}`.",
-      i = "Column `{i}` has already been selected."
+      "{.code {new_arg}} can't select a column already selected by {.code {old_arg}}.",
+      i = "Column {.code {col}} has already been selected."
     ),
     parent = NA,
     call = call

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -82,13 +82,14 @@ correct vector type even for empty list-columns.
 \item The unique values of the columns used to chop by are preserved losslessly
 as output columns, rather than being converted to character labels used as
 names on the output list. This is particularly useful when chopping by
-multiple columns.
+non-string columns or multiple columns.
 \item Multiple columns can be chopped at once, producing one list-column per
 chopped column. The closest \code{split()} equivalent is to split a data frame,
 which produces a result more similar to \code{\link[=nest]{nest()}} than \code{chop()}.
-\item When chopping by multiple columns, the \code{\link[=interaction]{interaction()}}s of those columns
-are not taken, and missing values are not dropped, which avoids a quadratic
-runtime and tends to produce more expected results in practice.
+\item When chopping by multiple columns, only the combinations present in the
+data are included in the output. This is different from \code{split()}, which
+takes the \code{\link[=interaction]{interaction()}} of the columns, leading to a potential
+combinatorial explosion of output elements.
 }
 
 For an even lower-level version, see \code{\link[vctrs:vec_split]{vctrs::vec_split()}}.
@@ -101,20 +102,19 @@ df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = c(1, 1, 2, 3, 3, 4), z = 1:6)
 # `chop()` is most useful as a tidyverse alternative to `base::split()`
 
 # Chop `z` by `x` and `y`. Note that we get one row of output for each unique
-# combination of non-chopped variables.
-df |> chop(z)
-
-# Equivalently, specify variables to chop by (rather than variables to chop)
-# using `by`
+# combination of variables that we chop by.
 df |> chop(by = c(x, y))
 
 # Compare to `split()`, notice how `x` and `y` are converted to character
 # labels
 df |> split(df[c("x", "y")], drop = TRUE)
 
+# Equivalently, specify variables to chop (rather than variables to chop by)
+df |> chop(cols = z)
+
 # `cols` and `by` can be used together to drop columns you no longer need.
 # This drops `y`:
-df |> chop(z, by = x)
+df |> chop(cols = z, by = x)
 
 # You cannot chop a column you are also trying to chop by
 try(df |> chop(cols = x, by = x))

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -19,22 +19,27 @@ unchop(
 \arguments{
 \item{data}{A data frame.}
 
-\item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to chop or unchop.
+\item{cols, by}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Column selectors.
 
-For \code{chop()}, columns specified by \code{by} are removed from \code{data} before
-evaluating \code{cols}. If not supplied, \code{cols} is derived as all columns \emph{not}
-selected by \code{by}. At least one of \code{cols} and \code{by} must be specified.
+For \code{chop()}:
+\itemize{
+\item \code{by} selects columns to chop by. If not specified, will be derived as
+all columns not selected by \code{cols}.
+\item \code{cols} selects columns to chop. If not specified, will be derived as all
+columns not selected by \code{by}.
+}
 
-For \code{unchop()}, each column should be a list-column containing generalised
-vectors (e.g. any mix of \code{NULL}s, atomic vector, S3 vectors, a lists,
-or data frames).}
+Specifying both \code{by} and \code{cols} drops all unselected columns in \code{data} from
+the output. Note that columns selected by \code{by} are removed from \code{data}
+before evaluating \code{cols}.
+
+At least one of \code{by} or \code{cols} must be specified.
+
+For \code{unchop()}, \code{cols} selects columns to unchop. Each column should be a
+list-column containing generalised vectors (e.g. any mix of \code{NULL}s, atomic
+vectors, S3 vectors, lists, or data frames).}
 
 \item{...}{These dots are for future extensions and must be empty.}
-
-\item{by}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to chop \emph{by}.
-
-If not supplied, then \code{by} is derived as all columns \emph{not} selected by
-\code{cols}. At least one of \code{cols} and \code{by} must be specified.}
 
 \item{error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -85,16 +85,16 @@ df |> chop(c(y, z))
 df |> nest(data = c(y, z))
 
 # Specify variables to chop by (rather than variables to chop) using `by`
-df \%>\% chop(by = x)
+df |> chop(by = x)
 # Compare to `nest()`
-df \%>\% nest(.by = x)
+df |> nest(.by = x)
 
 # `cols` and `by` can be used together to drop columns you no longer need.
 # This drops `z`:
-df \%>\% chop(cols = y, by = x)
+df |> chop(cols = y, by = x)
 
 # You cannot chop a column you are also trying to chop by
-try(df \%>\% chop(cols = x, by = x))
+try(df |> chop(cols = x, by = x))
 
 # Unchop --------------------------------------------------------------------
 df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -5,7 +5,7 @@
 \alias{unchop}
 \title{Chop and unchop}
 \usage{
-chop(data, cols = NULL, ..., by = NULL, error_call = current_env())
+chop(data, ..., cols = NULL, by = NULL, error_call = current_env())
 
 unchop(
   data,
@@ -18,6 +18,8 @@ unchop(
 }
 \arguments{
 \item{data}{A data frame.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{cols, by}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Column selectors.
 
@@ -38,8 +40,6 @@ At least one of \code{by} or \code{cols} must be specified.
 For \code{unchop()}, \code{cols} selects columns to unchop. Each column should be a
 list-column containing generalised vectors (e.g. any mix of \code{NULL}s, atomic
 vectors, S3 vectors, lists, or data frames).}
-
-\item{...}{These dots are for future extensions and must be empty.}
 
 \item{error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -21,8 +21,9 @@ unchop(
 
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to chop or unchop.
 
-If not supplied for \code{chop()}, then \code{cols} is derived as all columns \emph{not}
-selected by \code{by}.
+For \code{chop()}, columns specified by \code{by} are removed from \code{data} before
+evaluating \code{cols}. If not supplied, \code{cols} is derived as all columns \emph{not}
+selected by \code{by}. At least one of \code{cols} and \code{by} must be specified.
 
 For \code{unchop()}, each column should be a list-column containing generalised
 vectors (e.g. any mix of \code{NULL}s, atomic vector, S3 vectors, a lists,
@@ -30,14 +31,10 @@ or data frames).}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{by}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to chop \emph{by}; these
-will not be chopped.
-
-\code{by} can be used in place of or in conjunction with columns supplied
-through \code{cols}.
+\item{by}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to chop \emph{by}.
 
 If not supplied, then \code{by} is derived as all columns \emph{not} selected by
-\code{cols}.}
+\code{cols}. At least one of \code{cols} and \code{by} must be specified.}
 
 \item{error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
@@ -84,21 +81,20 @@ df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
 # Note that we get one row of output for each unique combination of
 # non-chopped variables
 df |> chop(c(y, z))
-# cf nest
+# Compare to `nest()`
 df |> nest(data = c(y, z))
 
 # Specify variables to chop by (rather than variables to chop) using `by`
 df \%>\% chop(by = x)
+# Compare to `nest()`
+df \%>\% nest(.by = x)
 
-# Use tidyselect syntax and helpers, just like in `dplyr::select()`
-df \%>\% chop(any_of(c("y", "z")))
-
-# `cols` and `by` can be used together to drop columns you no longer need,
-# or to chop the columns you are chopping by too.
+# `cols` and `by` can be used together to drop columns you no longer need.
 # This drops `z`:
-df \%>\% chop(y, by = x)
-# This includes `x` in the chopped columns:
-df \%>\% chop(everything(), by = x)
+df \%>\% chop(cols = y, by = x)
+
+# You cannot chop a column you are also trying to chop by
+try(df \%>\% chop(cols = x, by = x))
 
 # Unchop --------------------------------------------------------------------
 df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -5,7 +5,7 @@
 \alias{unchop}
 \title{Chop and unchop}
 \usage{
-chop(data, cols, ..., error_call = current_env())
+chop(data, cols = NULL, ..., by = NULL, error_call = current_env())
 
 unchop(
   data,
@@ -21,11 +21,23 @@ unchop(
 
 \item{cols}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to chop or unchop.
 
+If not supplied for \code{chop()}, then \code{cols} is derived as all columns \emph{not}
+selected by \code{by}.
+
 For \code{unchop()}, each column should be a list-column containing generalised
 vectors (e.g. any mix of \code{NULL}s, atomic vector, S3 vectors, a lists,
 or data frames).}
 
 \item{...}{These dots are for future extensions and must be empty.}
+
+\item{by}{<\code{\link[=tidyr_tidy_select]{tidy-select}}> Columns to chop \emph{by}; these
+will not be chopped.
+
+\code{by} can be used in place of or in conjunction with columns supplied
+through \code{cols}.
+
+If not supplied, then \code{by} is derived as all columns \emph{not} selected by
+\code{cols}.}
 
 \item{error_call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
@@ -74,6 +86,19 @@ df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
 df |> chop(c(y, z))
 # cf nest
 df |> nest(data = c(y, z))
+
+# Specify variables to chop by (rather than variables to chop) using `by`
+df \%>\% chop(by = x)
+
+# Use tidyselect syntax and helpers, just like in `dplyr::select()`
+df \%>\% chop(any_of(c("y", "z")))
+
+# `cols` and `by` can be used together to drop columns you no longer need,
+# or to chop the columns you are chopping by too.
+# This drops `z`:
+df \%>\% chop(y, by = x)
+# This includes `x` in the chopped columns:
+df \%>\% chop(everything(), by = x)
 
 # Unchop --------------------------------------------------------------------
 df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))

--- a/man/chop.Rd
+++ b/man/chop.Rd
@@ -55,17 +55,16 @@ can be supplied, which will be applied to all \code{cols}.}
 }
 \description{
 Chopping and unchopping preserve the width of a data frame, changing its
-length. \code{chop()} makes \code{df} shorter by converting rows within each group
-into list-columns. \code{unchop()} makes \code{df} longer by expanding list-columns
+length. \code{chop()} makes \code{data} shorter by converting rows within each group
+into list-columns. \code{unchop()} makes \code{data} longer by expanding list-columns
 so that each element of the list-column gets its own row in the output.
+
 \code{chop()} and \code{unchop()} are building blocks for more complicated functions
-(like \code{\link[=unnest]{unnest()}}, \code{\link[=unnest_longer]{unnest_longer()}}, and \code{\link[=unnest_wider]{unnest_wider()}}) and are generally
-more suitable for programming than interactive data analysis.
+(like \code{\link[=unnest]{unnest()}}, \code{\link[=unnest_longer]{unnest_longer()}}, and \code{\link[=unnest_wider]{unnest_wider()}}).
 }
 \details{
-Generally, unchopping is more useful than chopping because it simplifies
-a complex data structure, and \code{\link[=nest]{nest()}}ing is usually more appropriate
-than \code{chop()}ing since it better preserves the connections between
+When multiple columns are being chopped at once, \code{\link[=nest]{nest()}} is usually more
+appropriate than \code{chop()} since it better preserves the connections between
 observations.
 
 \code{chop()} creates list-columns of class \code{\link[vctrs:list_of]{vctrs::list_of()}} to ensure
@@ -75,38 +74,71 @@ the roundtrip chop and unchop. Because \verb{<list_of>} keeps tracks of
 the type of its elements, \code{unchop()} is able to reconstitute the
 correct vector type even for empty list-columns.
 }
+\section{Connection to \code{split()}}{
+
+
+\code{chop()} is the tidyverse version of \code{\link[base:split]{base::split()}}, with a few key changes:
+\itemize{
+\item The unique values of the columns used to chop by are preserved losslessly
+as output columns, rather than being converted to character labels used as
+names on the output list. This is particularly useful when chopping by
+multiple columns.
+\item Multiple columns can be chopped at once, producing one list-column per
+chopped column. The closest \code{split()} equivalent is to split a data frame,
+which produces a result more similar to \code{\link[=nest]{nest()}} than \code{chop()}.
+\item When chopping by multiple columns, the \code{\link[=interaction]{interaction()}}s of those columns
+are not taken, and missing values are not dropped, which avoids a quadratic
+runtime and tends to produce more expected results in practice.
+}
+
+For an even lower-level version, see \code{\link[vctrs:vec_split]{vctrs::vec_split()}}.
+}
+
 \examples{
 # Chop ----------------------------------------------------------------------
-df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
-# Note that we get one row of output for each unique combination of
-# non-chopped variables
-df |> chop(c(y, z))
-# Compare to `nest()`
-df |> nest(data = c(y, z))
+df <- tibble(x = c(1, 1, 1, 2, 2, 3), y = c(1, 1, 2, 3, 3, 4), z = 1:6)
 
-# Specify variables to chop by (rather than variables to chop) using `by`
-df |> chop(by = x)
-# Compare to `nest()`
-df |> nest(.by = x)
+# `chop()` is most useful as a tidyverse alternative to `base::split()`
+
+# Chop `z` by `x` and `y`. Note that we get one row of output for each unique
+# combination of non-chopped variables.
+df |> chop(z)
+
+# Equivalently, specify variables to chop by (rather than variables to chop)
+# using `by`
+df |> chop(by = c(x, y))
+
+# Compare to `split()`, notice how `x` and `y` are converted to character
+# labels
+df |> split(df[c("x", "y")], drop = TRUE)
 
 # `cols` and `by` can be used together to drop columns you no longer need.
-# This drops `z`:
-df |> chop(cols = y, by = x)
+# This drops `y`:
+df |> chop(z, by = x)
 
 # You cannot chop a column you are also trying to chop by
 try(df |> chop(cols = x, by = x))
+
+# Multiple columns can be chopped at once, producing one list-column per
+# chopped column
+df |> chop(by = x)
+# Compare to `nest()`, which keeps the chopped `y` and `z` columns together
+# in nested data frames
+df |> nest(.by = x)
+# `split()` is more similar to `nest()` here
+split(df[c("y", "z")], df["x"])
 
 # Unchop --------------------------------------------------------------------
 df <- tibble(x = 1:4, y = list(integer(), 1L, 1:2, 1:3))
 df |> unchop(y)
 df |> unchop(y, keep_empty = TRUE)
 
-# unchop will error if the types are not compatible:
+# `unchop()` will error if the types are not compatible:
 df <- tibble(x = 1:2, y = list("1", 1:3))
 try(df |> unchop(y))
 
 # Unchopping a list-col of data frames must generate a df-col because
-# unchop leaves the column names unchanged
+# `unchop()` leaves the column names unchanged
 df <- tibble(x = 1:3, y = list(NULL, tibble(x = 1), tibble(y = 1:2)))
 df |> unchop(y)
 df |> unchop(y, keep_empty = TRUE)

--- a/tests/testthat/_snaps/chop.md
+++ b/tests/testthat/_snaps/chop.md
@@ -12,7 +12,7 @@
       chop(df)
     Condition
       Error in `chop()`:
-      ! `cols` is absent but must be supplied.
+      ! At least one of `cols` or `by` must be supplied.
 
 # incompatible ptype mentions the column (#1477)
 

--- a/tests/testthat/_snaps/chop.md
+++ b/tests/testthat/_snaps/chop.md
@@ -17,7 +17,7 @@
 # can't select same column in `by` and `cols` (#1490)
 
     Code
-      chop(df, x, by = x)
+      chop(df, cols = x, by = x)
     Condition
       Error in `chop()`:
       ! `cols` can't reference a column already selected by `by`.
@@ -30,6 +30,56 @@
     Condition
       Error in `chop()`:
       ! At least one of `cols` or `by` must be supplied.
+
+# specifying `cols` by position is deprecated
+
+    Code
+      out <- chop(df, x)
+    Condition
+      Warning:
+      Specifying the `cols` argument by position was deprecated in tidyr 1.4.0.
+      i Please explicitly name `cols`, like `chop(data, cols = x)`.
+
+---
+
+    Code
+      out <- chop(df, x, by = y)
+    Condition
+      Warning:
+      Specifying the `cols` argument by position was deprecated in tidyr 1.4.0.
+      i Please explicitly name `cols`, like `chop(data, cols = x)`.
+
+---
+
+    Code
+      chop(df, x, y)
+    Condition
+      Error in `chop()`:
+      ! `...` must be empty.
+      x Problematic arguments:
+      * ..1 = x
+      * ..2 = y
+      i Did you forget to name an argument?
+
+---
+
+    Code
+      chop(df, x, cols = y)
+    Condition
+      Error in `chop()`:
+      ! Can't specify `cols` by both name and position.
+
+---
+
+    Code
+      my_chop()
+    Condition
+      Error in `chop()`:
+      ! `...` must be empty.
+      x Problematic arguments:
+      * ..1 = x
+      * ..2 = y
+      i Did you forget to name an argument?
 
 # incompatible ptype mentions the column (#1477)
 

--- a/tests/testthat/_snaps/chop.md
+++ b/tests/testthat/_snaps/chop.md
@@ -14,6 +14,23 @@
       Error in `chop()`:
       ! At least one of `cols` or `by` must be supplied.
 
+# can't select same column in `by` and `cols` (#1490)
+
+    Code
+      chop(df, x, by = x)
+    Condition
+      Error in `chop()`:
+      ! Can't select columns that don't exist.
+      x Column `x` doesn't exist.
+
+# must supply at least one of `by` or `cols`
+
+    Code
+      chop(df)
+    Condition
+      Error in `chop()`:
+      ! At least one of `cols` or `by` must be supplied.
+
 # incompatible ptype mentions the column (#1477)
 
     Code

--- a/tests/testthat/_snaps/chop.md
+++ b/tests/testthat/_snaps/chop.md
@@ -20,8 +20,8 @@
       chop(df, x, by = x)
     Condition
       Error in `chop()`:
-      ! Can't select columns that don't exist.
-      x Column `x` doesn't exist.
+      ! `cols` can't select a column already selected by `by`.
+      i Column `x` has already been selected.
 
 # must supply at least one of `by` or `cols`
 

--- a/tests/testthat/_snaps/chop.md
+++ b/tests/testthat/_snaps/chop.md
@@ -20,7 +20,7 @@
       chop(df, x, by = x)
     Condition
       Error in `chop()`:
-      ! `cols` can't select a column already selected by `by`.
+      ! `cols` can't reference a column already selected by `by`.
       i Column `x` has already been selected.
 
 # must supply at least one of `by` or `cols`

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -184,7 +184,7 @@
       Error in `build_wider_spec()`:
       ! `names_expand` must be `TRUE` or `FALSE`, not the string "x".
 
-# `id_cols` can't select columns from `names_from` or `values_from` (#1318)
+# `id_cols` can't select columns from `names_from` or `values_from` (#1318, #1506)
 
     Code
       pivot_wider(df, id_cols = name, names_from = name, values_from = value)
@@ -197,6 +197,24 @@
 
     Code
       pivot_wider(df, id_cols = value, names_from = name, values_from = value)
+    Condition
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `values_from`.
+      i Column `value` has already been selected.
+
+---
+
+    Code
+      pivot_wider(df, id_cols = all_of(cols), names_from = name, values_from = value)
+    Condition
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `names_from`.
+      i Column `name` has already been selected.
+
+---
+
+    Code
+      pivot_wider(df, id_cols = all_of(cols), names_from = name, values_from = value)
     Condition
       Error in `pivot_wider()`:
       ! `id_cols` can't select a column already selected by `values_from`.

--- a/tests/testthat/_snaps/pivot-wide.md
+++ b/tests/testthat/_snaps/pivot-wide.md
@@ -190,7 +190,7 @@
       pivot_wider(df, id_cols = name, names_from = name, values_from = value)
     Condition
       Error in `pivot_wider()`:
-      ! `id_cols` can't select a column already selected by `names_from`.
+      ! `id_cols` can't reference a column already selected by `names_from`.
       i Column `name` has already been selected.
 
 ---
@@ -199,7 +199,7 @@
       pivot_wider(df, id_cols = value, names_from = name, values_from = value)
     Condition
       Error in `pivot_wider()`:
-      ! `id_cols` can't select a column already selected by `values_from`.
+      ! `id_cols` can't reference a column already selected by `values_from`.
       i Column `value` has already been selected.
 
 ---
@@ -208,7 +208,7 @@
       pivot_wider(df, id_cols = all_of(cols), names_from = name, values_from = value)
     Condition
       Error in `pivot_wider()`:
-      ! `id_cols` can't select a column already selected by `names_from`.
+      ! `id_cols` can't reference a column already selected by `names_from`.
       i Column `name` has already been selected.
 
 ---
@@ -217,7 +217,7 @@
       pivot_wider(df, id_cols = all_of(cols), names_from = name, values_from = value)
     Condition
       Error in `pivot_wider()`:
-      ! `id_cols` can't select a column already selected by `values_from`.
+      ! `id_cols` can't reference a column already selected by `values_from`.
       i Column `value` has already been selected.
 
 # `id_cols` returns a tidyselect error if a column selection is OOB (#1318)

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -47,6 +47,41 @@ test_that("can chop empty data frame (#1206)", {
   )
 })
 
+test_that("can chop `by` columns (#1490)", {
+  df <- tibble(x = c(1, 1, 1, 2, 2), y = c(2, 1, 2, 3, 4), z = 1:5)
+
+  expect_identical(
+    chop(df, by = c(x, y)),
+    chop(df, z)
+  )
+})
+
+test_that("can combine `by` with `cols` (#1490)", {
+  df <- tibble(x = c(1, 1, 1, 2, 2), y = c(2, 1, 2, 3, 4), z = 1:5)
+
+  expect_identical(
+    chop(df, x, by = y),
+    chop(dplyr::select(df, -z), x)
+  )
+})
+
+test_that("union of `by` and `cols` results in renaming (#1490)", {
+  df <- tibble(x = 1, y = 1)
+  one <- vctrs::list_of(1)
+
+  with_options(rlib_name_repair_verbosity = "quiet", {
+    expect_identical(
+      invisible(chop(df, everything(), by = x)),
+      tibble(x = 1, x = one, y = one, .name_repair = "unique")
+    )
+
+    expect_identical(
+      invisible(chop(df, x, by = everything())),
+      tibble(x = 1, y = 1, x = one, .name_repair = "unique")
+    )
+  })
+})
+
 # unchop ------------------------------------------------------------------
 
 test_that("extends into rows", {

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -14,6 +14,14 @@ test_that("chopping no columns returns input", {
   expect_equal(chop(df, c()), df)
 })
 
+test_that("chopping by no columns chops all columns", {
+  df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
+  expect_identical(
+    chop(df, by = c()),
+    chop(df, c(a1, a2, b1, b2))
+  )
+})
+
 test_that("grouping is preserved", {
   df <- tibble(g = c(1, 1), x = 1:2)
   out <- df |> dplyr::group_by(g) |> chop(x)
@@ -59,26 +67,35 @@ test_that("can chop `by` columns (#1490)", {
 test_that("can combine `by` with `cols` (#1490)", {
   df <- tibble(x = c(1, 1, 1, 2, 2), y = c(2, 1, 2, 3, 4), z = 1:5)
 
+  # `by` cols come first, then `cols` cols. Unselected cols are dropped!
   expect_identical(
     chop(df, x, by = y),
-    chop(dplyr::select(df, -z), x)
+    chop(df[c("x", "y")], x)
   )
 })
 
-test_that("union of `by` and `cols` results in renaming (#1490)", {
-  df <- tibble(x = 1, y = 1)
-  one <- vctrs::list_of(1)
+test_that("`by` columns are removed before evaluating `cols` (#1490)", {
+  # Similar to `id_cols` in `pivot_wider()`
+  df <- tibble(x = 1, y = 2, by = 3)
 
-  with_options(rlib_name_repair_verbosity = "quiet", {
-    expect_identical(
-      invisible(chop(df, everything(), by = x)),
-      tibble(x = 1, x = one, y = one, .name_repair = "unique")
-    )
+  expect_identical(
+    chop(df, everything(), by = by),
+    chop(df, c(x, y))
+  )
+})
 
-    expect_identical(
-      invisible(chop(df, x, by = everything())),
-      tibble(x = 1, y = 1, x = one, .name_repair = "unique")
-    )
+test_that("can't select same column in `by` and `cols` (#1490)", {
+  df <- tibble(x = 1)
+
+  expect_snapshot(error = TRUE, {
+    chop(df, x, by = x)
+  })
+})
+
+test_that("must supply at least one of `by` or `cols`", {
+  df <- tibble(x = 1)
+  expect_snapshot(error = TRUE, {
+    chop(df)
   })
 })
 

--- a/tests/testthat/test-chop.R
+++ b/tests/testthat/test-chop.R
@@ -2,7 +2,7 @@
 
 test_that("can chop multiple columns", {
   df <- tibble(x = c(1, 1, 2), a = 1:3, b = 1:3)
-  out <- df |> chop(c(a, b))
+  out <- df |> chop(cols = c(a, b))
 
   expect_named(out, c("x", "a", "b"))
   expect_equal(out$a, list_of(1:2, 3L))
@@ -11,20 +11,20 @@ test_that("can chop multiple columns", {
 
 test_that("chopping no columns returns input", {
   df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
-  expect_equal(chop(df, c()), df)
+  expect_equal(chop(df, cols = c()), df)
 })
 
 test_that("chopping by no columns chops all columns", {
   df <- tibble(a1 = 1, a2 = 2, b1 = 1, b2 = 2)
   expect_identical(
     chop(df, by = c()),
-    chop(df, c(a1, a2, b1, b2))
+    chop(df, cols = c(a1, a2, b1, b2))
   )
 })
 
 test_that("grouping is preserved", {
   df <- tibble(g = c(1, 1), x = 1:2)
-  out <- df |> dplyr::group_by(g) |> chop(x)
+  out <- df |> dplyr::group_by(g) |> chop(cols = x)
   expect_equal(dplyr::group_vars(out), "g")
 })
 
@@ -42,15 +42,15 @@ test_that("can chop empty data frame (#1206)", {
   df <- tibble(x = integer(), y = integer())
 
   expect_identical(
-    chop(df, y),
+    chop(df, cols = y),
     tibble(x = integer(), y = list_of(.ptype = integer()))
   )
   expect_identical(
-    chop(df, x),
+    chop(df, cols = x),
     tibble(y = integer(), x = list_of(.ptype = integer()))
   )
   expect_identical(
-    chop(df, c(x, y)),
+    chop(df, cols = c(x, y)),
     tibble(x = list_of(.ptype = integer()), y = list_of(.ptype = integer()))
   )
 })
@@ -60,7 +60,7 @@ test_that("can chop `by` columns (#1490)", {
 
   expect_identical(
     chop(df, by = c(x, y)),
-    chop(df, z)
+    chop(df, cols = z)
   )
 })
 
@@ -69,8 +69,8 @@ test_that("can combine `by` with `cols` (#1490)", {
 
   # `by` cols come first, then `cols` cols. Unselected cols are dropped!
   expect_identical(
-    chop(df, x, by = y),
-    chop(df[c("x", "y")], x)
+    chop(df, cols = x, by = y),
+    chop(df[c("x", "y")], cols = x)
   )
 })
 
@@ -79,8 +79,8 @@ test_that("`by` columns are removed before evaluating `cols` (#1490)", {
   df <- tibble(x = 1, y = 2, by = 3)
 
   expect_identical(
-    chop(df, everything(), by = by),
-    chop(df, c(x, y))
+    chop(df, cols = everything(), by = by),
+    chop(df, cols = c(x, y))
   )
 })
 
@@ -88,7 +88,7 @@ test_that("can't select same column in `by` and `cols` (#1490)", {
   df <- tibble(x = 1)
 
   expect_snapshot(error = TRUE, {
-    chop(df, x, by = x)
+    chop(df, cols = x, by = x)
   })
 })
 
@@ -96,6 +96,40 @@ test_that("must supply at least one of `by` or `cols`", {
   df <- tibble(x = 1)
   expect_snapshot(error = TRUE, {
     chop(df)
+  })
+})
+
+test_that("specifying `cols` by position is deprecated", {
+  df <- tibble(x = 1, y = 2, z = 3)
+
+  # Deprecation warning, but works
+  expect_snapshot({
+    out <- chop(df, x)
+  })
+  expect_identical(out, chop(df, cols = x))
+
+  # Deprecation warning, but works (with `by`)
+  expect_snapshot({
+    out <- chop(df, x, by = y)
+  })
+  expect_identical(out, chop(df, cols = x, by = y))
+
+  # Two positional `...`, empty dots error
+  expect_snapshot(error = TRUE, {
+    chop(df, x, y)
+  })
+
+  # Both positional and named, error
+  expect_snapshot(error = TRUE, {
+    chop(df, x, cols = y)
+  })
+
+  # Reports `chop()` as the call regardless of `error_call`
+  my_chop <- function() {
+    chop(df, x, y)
+  }
+  expect_snapshot(error = TRUE, {
+    my_chop()
   })
 })
 
@@ -335,7 +369,7 @@ test_that("unchopping list of empty types retains type", {
 })
 
 test_that("unchop retrieves correct types with emptied chopped df", {
-  chopped <- chop(tibble(x = 1:3, y = 4:6), y)
+  chopped <- chop(tibble(x = 1:3, y = 4:6), cols = y)
   empty <- vec_slice(chopped, 0L)
   expect_identical(unchop(empty, y), tibble(x = integer(), y = integer()))
 })

--- a/tests/testthat/test-pivot-wide.R
+++ b/tests/testthat/test-pivot-wide.R
@@ -445,7 +445,7 @@ test_that("`id_cols = everything()` excludes `names_from` and `values_from`", {
   )
 })
 
-test_that("`id_cols` can't select columns from `names_from` or `values_from` (#1318)", {
+test_that("`id_cols` can't select columns from `names_from` or `values_from` (#1318, #1506)", {
   df <- tibble(name = c("x", "y"), value = c(1, 2))
 
   # And gives a nice error message!
@@ -454,6 +454,27 @@ test_that("`id_cols` can't select columns from `names_from` or `values_from` (#1
   })
   expect_snapshot(error = TRUE, {
     pivot_wider(df, id_cols = value, names_from = name, values_from = value)
+  })
+
+  # With `all_of()` selecting multiple columns, we report the first matched problem
+  cols <- c("name", "nonexistent")
+  expect_snapshot(error = TRUE, {
+    pivot_wider(
+      df,
+      id_cols = all_of(cols),
+      names_from = name,
+      values_from = value
+    )
+  })
+
+  cols <- c("value", "nonexistent")
+  expect_snapshot(error = TRUE, {
+    pivot_wider(
+      df,
+      id_cols = all_of(cols),
+      names_from = name,
+      values_from = value
+    )
   })
 })
 


### PR DESCRIPTION
Fixes #1490
Fixes #1506

Snags:

1. In the absence of both `cols` and `by`, should we 'chop everything' as `nest()` does? I have thrown an error instead.
2. Should `chop()` use group vars if `data` is grouped, as `nest()` does? Would this require a generic?
3. What should happen if a column is selected by both `cols` and `by`? For now, the name is duplicated and repaired.

An example for the latter point:
```r
df <- tibble(x = c(1, 1, 1, 2, 2), y = c(2, 1, 2, 3, 4), z = 1:5)
nest(df, data = everything(), .by = y)
#> # A tibble: 4 × 2
#>       y data            
#>   <dbl> <list>          
#> 1     2 <tibble [2 × 3]>
#> 2     1 <tibble [1 × 3]>
#> 3     3 <tibble [1 × 3]>
#> 4     4 <tibble [1 × 3]>
chop(df, everything(), by = y)
#> New names:
#> • `y` -> `y...1`
#> • `y` -> `y...3`
#> # A tibble: 4 × 4
#>   y...1           x       y...3           z
#>   <dbl> <list<dbl>> <list<dbl>> <list<int>>
#> 1     2         [2]         [2]         [2]
#> 2     1         [1]         [1]         [1]
#> 3     3         [1]         [1]         [1]
#> 4     4         [1]         [1]         [1]
```