### PR TITLE
Improve example for expand

### DIFF
--- a/R/expand.R
+++ b/R/expand.R
@@ -47,7 +47,7 @@
 #' # Finding combinations ------------------------------------------------------
 #' fruits <- tibble(
 #'   type = c("apple", "orange", "apple", "orange", "orange", "orange"),
-#'   year = c(2010, 2010, 2012, 2010, 2011, 2012),
+#'   year = c(2010, 2010, 2012, 2014, 2011, 2012),
 #'   size = factor(
 #'     c("XS", "S", "M", "S", "S", "M"),
 #'     levels = c("XS", "S", "M", "L")
@@ -70,7 +70,8 @@
 #' # Other uses ----------------------------------------------------------------
 #' # Use with `full_seq()` to fill in values of continuous variables
 #' fruits %>% expand(type, size, full_seq(year, 1))
-#' fruits %>% expand(type, size, 2010:2013)
+#' # Or write range explicitly
+#' fruits %>% expand(type, size, 2010:2014)
 #'
 #' # Use `anti_join()` to determine which observations are missing
 #' all <- fruits %>% expand(type, size, year)

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -66,7 +66,7 @@ With grouped data frames created by \code{\link[dplyr:group_by]{dplyr::group_by(
 # Finding combinations ------------------------------------------------------
 fruits <- tibble(
   type = c("apple", "orange", "apple", "orange", "orange", "orange"),
-  year = c(2010, 2010, 2012, 2010, 2011, 2012),
+  year = c(2010, 2010, 2012, 2014, 2011, 2012),
   size = factor(
     c("XS", "S", "M", "S", "S", "M"),
     levels = c("XS", "S", "M", "L")
@@ -89,7 +89,8 @@ fruits \%>\% expand(nesting(type, size, year))
 # Other uses ----------------------------------------------------------------
 # Use with `full_seq()` to fill in values of continuous variables
 fruits \%>\% expand(type, size, full_seq(year, 1))
-fruits \%>\% expand(type, size, 2010:2013)
+# Or write range explicitly
+fruits \%>\% expand(type, size, 2010:2014)
 
 # Use `anti_join()` to determine which observations are missing
 all <- fruits \%>\% expand(type, size, year)


### PR DESCRIPTION
There was nothing really wrong with the docs, but I was reading through them myself and I realized the `full_seq` example wasn't particularly inspiring, since the example tibble already had a full range of values from `2010` to `2012`. To my understanding, this `full_seq` did nothing, so I changed one year in the example tibble to `2014` to make it include the missing `2013`.

I think this small change doesn't affect the original aim of any of the other examples. Do correct me if I'm wrong.