### PR TITLE
Add "Supported By Posit" badge to website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,14 +2,14 @@ url: https://tidyr.tidyverse.org
 
 home:
   links:
-    - text: Learn more
-      href: https://r4ds.hadley.nz/data-tidy
+  - text: Learn more
+    href: https://r4ds.hadley.nz/data-tidy
 
 navbar:
   structure:
     right: [search, github, ai]
   components:
-    home: ~
+    home:
     intro:
       text: Tidy data
       href: articles/tidy-data.html
@@ -23,6 +23,7 @@ template:
   package: tidytemplate
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-hide-below="1200" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="tidyr.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
       <script async src="https://widget.kapa.ai/kapa-widget.bundle.js"
       data-button-hide="true"
@@ -106,9 +107,9 @@ reference:
 
 - title: Superseded
   description: |
-     Superseded functions have been replaced by superior solutions, but
-     due to their widespread use will not go away. However, they will not
-     get any new features and will only receive critical bug fixes.
+    Superseded functions have been replaced by superior solutions, but
+    due to their widespread use will not go away. However, they will not
+    get any new features and will only receive critical bug fixes.
   contents:
   - extract
   - separate
@@ -119,7 +120,7 @@ reference:
 
 articles:
 - title: Tidying tools
-  navbar: ~
+  navbar:
   contents:
   - pivot
   - rectangle


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

The badge is hidden between 992px and 1199px browser width to prevent the header from breaking.

At 1200px browser width:

<img width="1200" height="300" alt="tidyr-1200" src="https://github.com/user-attachments/assets/02fb0250-39dd-4b16-a79f-68d8182894ef" />

At 992px browser width:

<img width="992" height="300" alt="tidyr-992" src="https://github.com/user-attachments/assets/5b687f79-6fa5-4eb2-bf13-fcddc97809e9" />

At 991px browser width:

<img width="991" height="300" alt="tidyr-991" src="https://github.com/user-attachments/assets/a8eb2fd3-a3a0-47e7-8d55-17ad688ead44" />


