### PR TITLE
Fix data masking in uncount()

### DIFF
--- a/tests/testthat/test-uncount.R
+++ b/tests/testthat/test-uncount.R
@@ -48,3 +48,8 @@ test_that("validates inputs", {
     uncount(df, x, .id = "")
   })
 })
+
+test_that("works with data masking", {
+  df <- tibble(x = 1, w = 2)
+  expect_equal(uncount(df, .data$w), uncount(df, w))
+})


### PR DESCRIPTION
Proposed fix to issue [#1583](https://github.com/tidyverse/tidyr/issues/1583).

If `.remove = TRUE`, `uncount()` should remove the weight column from the output. Currently this only happens when `weight` is a variable, but not when using `.data$var`, because the column is set to `NULL` only when `quo_is_symbol(weights_quo)` is TRUE.

The PR adds another condition that looks for a data masking expression, and if found, sets the `weight` variable to NULL. A new test shows that `uncount(df, var)` and `uncount(df, .data$var)` now give the same output.

This PR was prepared in collaboration with @gguyver.