### PR TITLE
Update docs for expand_grid to include an example using a named list and the splice operator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidyr (development version)
 
+* Docs for `expand_grid` now include an example using a named list and the splice operator, a common use case.
+
 * `fill()` gains a `.by` argument as an alternative to `dplyr::group_by()` for
   applying the fill per group, similar to `nest(.by =)` and
   `dplyr::mutate(.by =)` (@olivroy, #1439).

--- a/R/expand.R
+++ b/R/expand.R
@@ -192,6 +192,10 @@ nesting <- function(..., .name_repair = "check_unique") {
 #'
 #' # And matrices
 #' expand_grid(x1 = matrix(1:4, nrow = 2), x2 = matrix(5:8, nrow = 2))
+#'
+#' # And named lists using the splice operator
+#' my_params <- list(a = 1:3, b = c("a", "b", "c", "d"))
+#' expand_grid(!!!my_params)
 expand_grid <- function(..., .name_repair = "check_unique", .vary = "slowest") {
   out <- grid_dots(...)
 


### PR DESCRIPTION
Update docs for `expand_grid` to include an example using a named list and the splice operator, a common use case (I suspect many users might not know about the splice operator -- I didn't).