### PR TITLE
Update Kapa.ai settings to be more privacy friendly

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -35,7 +35,8 @@ template:
       data-project-name="tidyr"
       data-modal-title="tidyverse AI ✨"
       data-project-logo="https://avatars.githubusercontent.com/u/22032646?s=200&u=235532df5cf8543246812f73db051b793f868807&v=4"
-      data-user-analytics-fingerprint-enabled="true"
+      data-user-analytics-fingerprint-enabled="false"
+      data-user-analytics-cookie-enabled="false"
       data-bot-protection-mechanism="hcaptcha"
       data-website-id="34242a59-6aeb-4105-9065-86e16bf56a0f"
       ></script>


### PR DESCRIPTION
When I set up Kapa.ai for the Positron site, I figured out how to configure it so that it does not drop cookies and is more privacy friendly. We can do the same here!

Without these changes, these pkgdown sites should really have cookie consent on them.