### PR TITLE
Clarify crossing factor level behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # tidyr (development version)
 
+* The `crossing()` documentation now clarifies that factor inputs use the full
+  set of levels, not just the values present in the data (#1526).
+
 * `chop()` gains a `by` argument for specifying grouping columns, similar to `nest(.by =)` (@hrryt, #1490).
 
 * Specifying `chop()`'s `cols` argument by position is soft-deprecated. It must instead be specified by name, which better communicates intent now that `chop()` also has a `by` argument (#1490).

--- a/R/expand.R
+++ b/R/expand.R
@@ -33,9 +33,9 @@
 #'     a row for each present school-student combination for all possible
 #'     dates.
 #'
-#'   When used with factors, [expand()] and [complete()] use the full set of
-#'   levels, not just those that appear in the data. If you want to use only the
-#'   values seen in the data, use `forcats::fct_drop()`.
+#'   When used with factors, [expand()], [complete()], and [crossing()] use the
+#'   full set of levels, not just those that appear in the data. If you want to
+#'   use only the values seen in the data, use `forcats::fct_drop()`.
 #'
 #'   When used with continuous variables, you may need to fill in values
 #'   that do not appear in the data: to do so use expressions like

--- a/man/expand.Rd
+++ b/man/expand.Rd
@@ -29,9 +29,9 @@ a row for each present school-student combination for all possible
 dates.
 }
 
-When used with factors, \code{\link[=expand]{expand()}} and \code{\link[=complete]{complete()}} use the full set of
-levels, not just those that appear in the data. If you want to use only the
-values seen in the data, use \code{forcats::fct_drop()}.
+When used with factors, \code{\link[=expand]{expand()}}, \code{\link[=complete]{complete()}}, and \code{\link[=crossing]{crossing()}} use the
+full set of levels, not just those that appear in the data. If you want to
+use only the values seen in the data, use \code{forcats::fct_drop()}.
 
 When used with continuous variables, you may need to fill in values
 that do not appear in the data: to do so use expressions like


### PR DESCRIPTION
Fixes #1526.

This clarifies that `crossing()` uses the full set of levels for factor inputs, not just the values present in the data. I kept the change scoped to `crossing()` because `nesting()` and `expand_grid()` do not independently expand factor levels in the same way.

Checks:
- Focused check confirming `crossing()` expands the missing factor level in the issue reprex
- `Rscript -e 'tools::checkRd("man/expand.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `R_LIBS_USER=/tmp/tune-r-lib _R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests tidyr_1.3.2.9000.tar.gz`