### PR TITLE
docs: clarify cols_remove behavior in separate_wider_*() (#1587)

### DIFF
--- a/R/separate-wider.R
+++ b/R/separate-wider.R
@@ -55,6 +55,9 @@
 #'     additional pieces.
 #' @param cols_remove Should the input `cols` be removed from the output?
 #'   Always `FALSE` if `too_few` or `too_many` are set to `"debug"`.
+#'   When `FALSE`, the input column is retained after the new columns,
+#'   which differs from [separate()] where `remove = FALSE` preserves the
+#'   original column position.
 #' @returns A data frame based on `data`. It has the same rows, but different
 #'   columns:
 #'


### PR DESCRIPTION
## Summary

Clarifies the documentation for `cols_remove` in `separate_wider_delim()`, `separate_wider_position()`, and `separate_wider_regex()`.

When `cols_remove = FALSE`, the input column is retained **after** the new columns, which differs from `separate()` where `remove = FALSE` preserves the original column position.

## Issue

Closes #1587

## Changes

- `R/separate-wider.R`: Added note to `@param cols_remove` documenting the column position behavior

## Validation

All existing tests pass: `[ FAIL 0 | WARN 0 | SKIP 161 | PASS 1061 ]`
