### PR TITLE
fix: full_seq() ignores infinite values (#1496)

### DIFF
--- a/R/seq.R
+++ b/R/seq.R
@@ -20,11 +20,15 @@ full_seq.numeric <- function(x, period, tol = 1e-6) {
   check_number_decimal(period)
   check_number_decimal(tol, min = 0)
 
-  rng <- range(x, na.rm = TRUE)
+  # Filter out infinite values before computing range
+  finite <- is.finite(x)
+  x_finite <- x[finite]
+
+  rng <- range(x_finite, na.rm = TRUE)
   if (
     any(
-      ((x - rng[1]) %% period > tol) &
-        (period - (x - rng[1]) %% period > tol)
+      ((x_finite - rng[1]) %% period > tol) &
+        (period - (x_finite - rng[1]) %% period > tol)
     )
   ) {
     cli::cli_abort("{.arg x} is not a regular sequence.")

--- a/tests/testthat/test-seq.R
+++ b/tests/testthat/test-seq.R
@@ -36,3 +36,18 @@ test_that("validates inputs", {
     full_seq(x, 1, tol = "a")
   })
 })
+
+test_that("full_seq ignores infinite values (#1496)", {
+  expect_equal(full_seq(c(1, Inf, 5), 1), 1:5)
+  expect_equal(full_seq(c(-Inf, 1, 5), 1), 1:5)
+  expect_equal(full_seq(c(-Inf, 1, 5, Inf), 1), 1:5)
+  expect_equal(full_seq(c(1, Inf), 1), 1)
+  expect_equal(full_seq(c(-Inf, 5), 1), 5)
+})
+
+test_that("full_seq ignores infinite values in Date (#1496)", {
+  x <- as.Date("2019-01-05") + c(0, 5)
+  expected <- seq(x[1], x[2], by = 1)
+  x_inf <- c(x, Inf)
+  expect_equal(full_seq(x_inf, 1), expected)
+})


### PR DESCRIPTION
## Summary

Fixes `full_seq()` to properly handle infinite values (`Inf` and `-Inf`) in the input vector.

## Problem

Currently, `full_seq()` fails with a cryptic error when the input contains infinite values:

```r
tidyr::full_seq(c(1, Inf), 1L)
#> Error in if (any(((x - rng[1])%%period > tol) & (period - (x - rng[1])%%period > : 
#>   missing value where TRUE/FALSE needed
```

This happens because `range()` returns `Inf`, and subsequent modulo operations produce `NaN`.

## Solution

Filter out infinite values before computing the range and checking periodicity. This is consistent with how `na.rm = TRUE` already handles `NA` values.

## Changes

- `R/seq.R`: Added filtering of infinite values before range computation (+4 lines)
- `tests/testthat/test-seq.R`: Added tests for infinite value handling (+14 lines)

## Validation

- All seq tests pass: `[ FAIL 0 | WARN 0 | SKIP 2 | PASS 12 ]`
- New tests verify Inf, -Inf, and combined infinite value handling
- Date method also works correctly with infinite values

## Related

- Fixes #1496
- Issue was filed by @DavisVaughan (tidyr maintainer)