### PR TITLE
tests: add factor edge-case tests for extract()

### DIFF
--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -102,3 +102,38 @@ test_that("validates its inputs", {
     df |> extract(x, into = "x", convert = 1)
   })
 })
+
+test_that("extract converts factor columns to character", {
+  df <- tibble(x = factor(c("a-b", "c-d"), levels = c("a-b", "c-d", "e-f")))
+  out <- extract(df, x, c("a", "b"), "([[:alnum:]]+)-([[:alnum:]]+)")
+
+  expect_identical(class(out$a), "character")
+  expect_identical(class(out$b), "character")
+  expect_identical(out$a, c("a", "c"))
+  expect_identical(out$b, c("b", "d"))
+})
+
+test_that("extract preserves NA values in factor columns", {
+  df <- tibble(x = factor(c("a-b", NA), levels = c("a-b", "c-d")))
+  out <- extract(df, x, c("a", "b"), "([[:alnum:]]+)-([[:alnum:]]+)")
+
+  expect_identical(out$a, c("a", NA))
+  expect_identical(out$b, c("b", NA))
+})
+
+test_that("extract with convert = TRUE works on factor input", {
+  df <- tibble(x = factor(c("1-2", "3-4")))
+  out <- extract(df, x, c("a", "b"), "(\\d+)-(\\d+)", convert = TRUE)
+
+  expect_identical(out$a, c(1L, 3L))
+  expect_identical(out$b, c(2L, 4L))
+})
+
+test_that("extract handles factor columns with unused levels", {
+  df <- tibble(x = factor(c("a1", "b2"), levels = c("a1", "b2", "c3", "d4")))
+  out <- extract(df, x, c("letter", "number"), "([a-z])(\\d)")
+
+  expect_identical(class(out$letter), "character")
+  expect_identical(out$letter, c("a", "b"))
+  expect_identical(out$number, c("1", "2"))
+})


### PR DESCRIPTION
## What

Add edge-case tests for `extract()` covering factor column inputs:
- Factor columns are converted to character before extraction
- NA values in factor columns are preserved
- Factor input works with `convert = TRUE`
- Factor columns with unused levels extract correctly

## Why

`extract()` converts factor columns via `as.character()` internally (line 71 of `R/extract.R`), but this behavior had no test coverage. These edge cases are important for data cleaning pipelines where factor columns are common.

## Testing

- All 4 new tests pass (22 total expectations, up from 11)
- No regressions in existing tests
- `devtools::test(filter = 'extract')` passes cleanly (pre-existing internal function test skipped as expected)

## Files changed

- `tests/testthat/test-extract.R` — added 35 lines of factor edge-case tests