### PR TITLE
tests: add edge-case tests for uncount()

### DIFF
--- a/tests/testthat/test-uncount.R
+++ b/tests/testthat/test-uncount.R
@@ -48,3 +48,59 @@ test_that("validates inputs", {
     uncount(df, x, .id = "")
   })
 })
+
+test_that("preserves factor columns", {
+  df <- tibble(x = factor(c("a", "b")), w = c(2L, 3L))
+  out <- uncount(df, w)
+
+  expect_s3_class(out$x, "factor")
+  expect_equal(levels(out$x), c("a", "b"))
+  expect_equal(nrow(out), 5)
+})
+
+test_that("preserves date columns", {
+  dates <- as.Date(c("2024-01-01", "2024-06-15"))
+  df <- tibble(d = dates, w = c(2L, 1L))
+  out <- uncount(df, w)
+
+  expect_s3_class(out$d, "Date")
+  expect_equal(out$d, dates[c(1, 1, 2)])
+})
+
+test_that("preserves POSIXct columns", {
+  times <- as.POSIXct(c("2024-01-01 10:00:00", "2024-06-15 14:30:00"), tz = "UTC")
+  df <- tibble(t = times, w = c(1L, 2L))
+  out <- uncount(df, w)
+
+  expect_s3_class(out$t, "POSIXct")
+  expect_equal(out$t, times[c(1, 2, 2)])
+})
+
+test_that(".id counter resets per group", {
+  df <- tibble(g = c(1, 1, 2), x = c("a", "b", "c"), w = c(2L, 1L, 3L))
+  out <- df |> dplyr::group_by(g) |> uncount(w, .id = "id")
+
+  expect_equal(out$id, c(1L, 2L, 1L, 1L, 2L, 3L))
+  expect_equal(dplyr::group_vars(out), "g")
+})
+
+test_that("all zero weights produce empty data frame", {
+  df <- tibble(x = 1:3, w = c(0L, 0L, 0L))
+  out <- uncount(df, w)
+
+  expect_equal(nrow(out), 0)
+  expect_named(out, c("x"))
+})
+
+test_that("errors on NA weights", {
+  df <- tibble(x = 1:2, w = c(1L, NA_integer_))
+  expect_error(uncount(df, w), "missing")
+})
+
+test_that("preserves list columns", {
+  df <- tibble(x = list(1, "a"), w = c(2L, 3L))
+  out <- uncount(df, w)
+
+  expect_equal(length(out$x), 5)
+  expect_equal(out$x, list(1, 1, "a", "a", "a"))
+})


### PR DESCRIPTION
Adds 7 edge-case test blocks for `uncount()` covering:

- Factor column preservation
- Date column preservation
- POSIXct column preservation
- `.id` counter resetting per group
- All zero weights producing empty data frame
- NA weights producing informative error
- List column preservation

All 24 tests pass (10 existing + 14 new). No regressions introduced.

Note: PR #1619 addresses the `.data` pronoun bug in `uncount()` — this PR focuses purely on test coverage for data cleaning edge cases.